### PR TITLE
feat: transparent GPU routing, centralized factories, LSP corrections, and conditional refactoring

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -276,6 +276,37 @@
         </plugins>
       </build>
     </profile>
+    <profile>
+      <id>gpu</id>
+      <activation>
+        <property>
+          <name>tfhe.gpu</name>
+          <value>true</value>
+        </property>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <configuration>
+              <systemPropertyVariables>
+                <cucumber.filter.tags>@gpu</cucumber.filter.tags>
+              </systemPropertyVariables>
+            </configuration>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-failsafe-plugin</artifactId>
+            <configuration>
+              <systemPropertyVariables>
+                <cucumber.filter.tags>@gpu</cucumber.filter.tags>
+              </systemPropertyVariables>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
   </profiles>
 
 </project>

--- a/tfhe-java/src/main/java/io/github/rdlopes/tfhe/api/AbstractFheType.java
+++ b/tfhe-java/src/main/java/io/github/rdlopes/tfhe/api/AbstractFheType.java
@@ -15,6 +15,7 @@ import java.util.function.Function;
 import static io.github.rdlopes.tfhe.api.serde.DynamicBuffer.MAX_SERIALIZATION_SIZE;
 import static io.github.rdlopes.tfhe.ffm.NativeCall.*;
 
+
 /// Abstract base class for all FHE encrypted integer types (signed and unsigned).
 ///
 /// Every one of the 13 native call patterns is implemented exactly once here
@@ -49,6 +50,24 @@ public abstract class AbstractFheType<
   /// Allocates a new empty output slot of type `C`.
   protected abstract C newCompressed();
 
+  /// Returns the GPU routing [GpuRouter.Capability] for operations on this type.
+  ///
+  /// - [GpuRouter.Capability#GPU] — the type is supported by the TFHE-rs CUDA backend
+  ///   (all `FheUint*` types).
+  /// - [GpuRouter.Capability#CPU] — the type is CPU-only; it must not be dispatched to the
+  ///   GPU executor thread (all `FheInt*` types, since the TFHE-rs CUDA backend
+  ///   does not implement signed-integer operations).
+  ///
+  /// Subclasses may override this method to enforce CPU-only routing.
+  /// Note that [#compress()] and [#multiplyWithOverflow(T)] are **always** CPU-only
+  /// regardless of what this method returns.
+  protected io.github.rdlopes.tfhe.ffm.GpuRouter.Capability gpuCapability() {
+    // FheSignedInteger types are not supported by the TFHE-rs CUDA backend
+    return (this instanceof FheSignedInteger<?, ?, ?>)
+        ? io.github.rdlopes.tfhe.ffm.GpuRouter.Capability.CPU
+        : io.github.rdlopes.tfhe.ffm.GpuRouter.Capability.GPU;
+  }
+
   // ── Constructor ─────────────────────────────────────────────────────────────
 
   /// @param destroyRef method reference to the type-specific destroy function,
@@ -66,53 +85,53 @@ public abstract class AbstractFheType<
   /// P7 — unary → T result
   private T unary(FheOps.UnaryOp op) {
     T r = newInstance();
-    execute(() -> op.apply(getValue(), r.getAddress()));
+    io.github.rdlopes.tfhe.ffm.GpuRouter.execute(gpuCapability(), () -> op.apply(getValue(), r.getAddress()));
     return r;
   }
 
   /// P1 — binary → T result
   private T binary(FheOps.BinaryOp op, T other) {
     T r = newInstance();
-    execute(() -> op.apply(getValue(), other.getValue(), r.getAddress()));
+    io.github.rdlopes.tfhe.ffm.GpuRouter.execute(gpuCapability(), () -> op.apply(getValue(), other.getValue(), r.getAddress()));
     return r;
   }
 
   /// P2/P3 — scalar → T result
   private T scalar(FheOps.ScalarOp<V> op, V v) {
     T r = newInstance();
-    execute(() -> op.apply(getValue(), v, r.getAddress()));
+    io.github.rdlopes.tfhe.ffm.GpuRouter.execute(gpuCapability(), () -> op.apply(getValue(), v, r.getAddress()));
     return r;
   }
 
   /// P1 → FheBool result
   private FheBool binaryBool(FheOps.BinaryOp op, T other) {
     FheBool r = FheBool.newEmpty();
-    execute(() -> op.apply(getValue(), other.getValue(), r.getAddress()));
+    io.github.rdlopes.tfhe.ffm.GpuRouter.execute(gpuCapability(), () -> op.apply(getValue(), other.getValue(), r.getAddress()));
     return r;
   }
 
   /// P2/P3 → FheBool result
   private FheBool scalarBool(FheOps.ScalarOp<V> op, V v) {
     FheBool r = FheBool.newEmpty();
-    execute(() -> op.apply(getValue(), v, r.getAddress()));
+    io.github.rdlopes.tfhe.ffm.GpuRouter.execute(gpuCapability(), () -> op.apply(getValue(), v, r.getAddress()));
     return r;
   }
 
   /// P4 — assign binary
   private void assignBinary(FheOps.AssignOp op, T other) {
-    execute(() -> op.apply(getValue(), other.getValue()));
+    io.github.rdlopes.tfhe.ffm.GpuRouter.execute(gpuCapability(), () -> op.apply(getValue(), other.getValue()));
   }
 
   /// P5/P6 — assign scalar
   private void assignScalar(FheOps.ScalarAssignOp<V> op, V v) {
-    execute(() -> op.apply(getValue(), v));
+    io.github.rdlopes.tfhe.ffm.GpuRouter.execute(gpuCapability(), () -> op.apply(getValue(), v));
   }
 
   /// P8 — checked binary → [CheckedResult]
   private CheckedResult<T> checked(FheOps.CheckedOp op, T other) {
     T r = newInstance();
     FheBool flag = FheBool.newEmpty();
-    execute(() -> op.apply(getValue(), other.getValue(), r.getAddress(), flag.getAddress()));
+    io.github.rdlopes.tfhe.ffm.GpuRouter.execute(gpuCapability(), () -> op.apply(getValue(), other.getValue(), r.getAddress(), flag.getAddress()));
     return new CheckedResult<>(r, flag);
   }
 
@@ -120,7 +139,7 @@ public abstract class AbstractFheType<
   private QuotientAndRemainder<T> divRem(FheOps.CheckedOp op, T other) {
     T q = newInstance();
     T r = newInstance();
-    execute(() -> op.apply(getValue(), other.getValue(), q.getAddress(), r.getAddress()));
+    io.github.rdlopes.tfhe.ffm.GpuRouter.execute(gpuCapability(), () -> op.apply(getValue(), other.getValue(), q.getAddress(), r.getAddress()));
     return new QuotientAndRemainder<>(q, r);
   }
 
@@ -128,7 +147,7 @@ public abstract class AbstractFheType<
   private QuotientAndRemainder<T> scalarDivRem(FheOps.ScalarCheckedOp<V> op, V v) {
     T q = newInstance();
     T r = newInstance();
-    execute(() -> op.apply(getValue(), v, q.getAddress(), r.getAddress()));
+    io.github.rdlopes.tfhe.ffm.GpuRouter.execute(gpuCapability(), () -> op.apply(getValue(), v, q.getAddress(), r.getAddress()));
     return new QuotientAndRemainder<>(q, r);
   }
 
@@ -191,7 +210,15 @@ public abstract class AbstractFheType<
   @Override public final void                 subtractAssign(T o)        { assignBinary(handles().arithmetic().subAssign(), o); }
   @Override public final void                 subtractScalarAssign(V o)  { assignScalar(handles().arithmetic().scalarSubAssign(), o); }
   @Override public final T                    multiply(T o)              { return binary(handles().arithmetic().mul(), o); }
-  @Override public final CheckedResult<T>     multiplyWithOverflow(T o)  { return checked(handles().arithmetic().overflowingMul(), o); }
+  @Override public final CheckedResult<T>     multiplyWithOverflow(T o)  {
+    // overflowing_mul is not supported by the TFHE-rs CUDA backend — always use CPU.
+    T r = newInstance();
+    FheBool flag = FheBool.newEmpty();
+    io.github.rdlopes.tfhe.ffm.GpuRouter.execute(
+        io.github.rdlopes.tfhe.ffm.GpuRouter.Capability.CPU,
+        () -> handles().arithmetic().overflowingMul().apply(getValue(), o.getValue(), r.getAddress(), flag.getAddress()));
+    return new CheckedResult<>(r, flag);
+  }
   @Override public final T                    multiplyScalar(V o)        { return scalar(handles().arithmetic().scalarMul(), o); }
   @Override public final void                 multiplyAssign(T o)        { assignBinary(handles().arithmetic().mulAssign(), o); }
   @Override public final void                 multiplyScalarAssign(V o)  { assignScalar(handles().arithmetic().scalarMulAssign(), o); }
@@ -215,12 +242,12 @@ public abstract class AbstractFheType<
   public T ilog2() {
     if (this instanceof FheUint32) {
       T r = newInstance();
-      execute(() -> handles().arithmetic().ilog2().apply(getValue(), r.getAddress()));
+      io.github.rdlopes.tfhe.ffm.GpuRouter.execute(gpuCapability(), () -> handles().arithmetic().ilog2().apply(getValue(), r.getAddress()));
       return r;
     }
 
     try (FheUint32 u32 = FheRegistry.getFactory(FheUint32.class).get()) {
-      execute(() -> handles().arithmetic().ilog2().apply(getValue(), u32.getAddress()));
+      io.github.rdlopes.tfhe.ffm.GpuRouter.execute(gpuCapability(), () -> handles().arithmetic().ilog2().apply(getValue(), u32.getAddress()));
       return u32.castInto((Class<T>) this.getClass());
     }
   }
@@ -232,21 +259,20 @@ public abstract class AbstractFheType<
     if (this instanceof FheUint32) {
       T r = newInstance();
       FheBool flag = FheBool.newEmpty();
-      execute(() -> handles().arithmetic().checkedIlog2().apply(getValue(), r.getAddress(), flag.getAddress()));
+      io.github.rdlopes.tfhe.ffm.GpuRouter.execute(gpuCapability(), () -> handles().arithmetic().checkedIlog2().apply(getValue(), r.getAddress(), flag.getAddress()));
       return new CheckedResult<>(r, flag);
     }
 
     FheBool flag = FheBool.newEmpty();
     try (FheUint32 u32 = FheRegistry.getFactory(FheUint32.class).get()) {
-      execute(() -> handles().arithmetic().checkedIlog2().apply(getValue(), u32.getAddress(), flag.getAddress()));
+      io.github.rdlopes.tfhe.ffm.GpuRouter.execute(gpuCapability(), () -> handles().arithmetic().checkedIlog2().apply(getValue(), u32.getAddress(), flag.getAddress()));
       T r = u32.castInto((Class<T>) this.getClass());
       return new CheckedResult<>(r, flag);
     }
   }
   
-  /// `abs()` — only valid for signed types; exposed via [FheSignedInteger].
-  /// Overridden in [AbstractFheUnsignedInteger] to throw [UnsupportedOperationException].
-  public T abs() {
+  /// `absImpl()` — only valid for signed types; exposed via [FheSignedInteger].
+  protected final T absImpl() {
     return unary(handles().arithmetic().abs());
   }
 
@@ -281,8 +307,11 @@ public abstract class AbstractFheType<
 
   @Override
   public final C compress() {
+    // compress() is not supported by the TFHE-rs CUDA backend — always use CPU.
     C r = newCompressed();
-    execute(() -> handles().lifecycle().compress().apply(getValue(), r.getAddress()));
+    io.github.rdlopes.tfhe.ffm.GpuRouter.execute(
+        io.github.rdlopes.tfhe.ffm.GpuRouter.Capability.CPU,
+        () -> handles().lifecycle().compress().apply(getValue(), r.getAddress()));
     return r;
   }
 
@@ -383,14 +412,14 @@ public abstract class AbstractFheType<
   /// Returns a new random encrypted value using the given 128-bit seed.
   public final T random(long seedLow, long seedHigh) {
     T r = newInstance();
-    execute(() -> handles().misc().random().apply(r.getAddress(), seedLow, seedHigh));
+    io.github.rdlopes.tfhe.ffm.GpuRouter.execute(gpuCapability(), () -> handles().misc().random().apply(r.getAddress(), seedLow, seedHigh));
     return r;
   }
   
   /// Returns a new random encrypted value bounded to `bitsCount` significant bits.
   public final T random(long seedLow, long seedHigh, long bitsCount) {
     T r = newInstance();
-    execute(() -> handles().misc().randomBounded().apply(r.getAddress(), seedLow, seedHigh, bitsCount));
+    io.github.rdlopes.tfhe.ffm.GpuRouter.execute(gpuCapability(), () -> handles().misc().randomBounded().apply(r.getAddress(), seedLow, seedHigh, bitsCount));
     return r;
   }
 
@@ -399,8 +428,8 @@ public abstract class AbstractFheType<
   // ══════════════════════════════════════════════════════════════════════════
 
   /// Encrypt a value with a client key.
-/// Dispatches on [FheValueKind] to handle primitive vs. wide types.
-  protected static <V, T extends AbstractFheType<V, T, ?>> T encryptClientKey(
+  /// Dispatches on [FheValueKind] to handle primitive vs. wide types.
+  static <V, T extends AbstractFheType<V, T, ?>> T encryptClientKey(
       FheTypeHandles<V> h, V clear, ClientKey key, java.util.function.Supplier<T> factory) {
     T r = factory.get();
     execute(() -> switch (h.valueKind()) {
@@ -414,7 +443,7 @@ public abstract class AbstractFheType<
   }
 
   /// Encrypt a value with a public key.
-  protected static <V, T extends AbstractFheType<V, T, ?>> T encryptPublicKey(
+  static <V, T extends AbstractFheType<V, T, ?>> T encryptPublicKey(
       FheTypeHandles<V> h, V clear, PublicKey key, java.util.function.Supplier<T> factory) {
     T r = factory.get();
     execute(() -> switch (h.valueKind()) {
@@ -428,7 +457,7 @@ public abstract class AbstractFheType<
   }
 
   /// Encrypt a value trivially (no key).
-  protected static <V, T extends AbstractFheType<V, T, ?>> T encryptTrivial(
+  static <V, T extends AbstractFheType<V, T, ?>> T encryptTrivial(
       FheTypeHandles<V> h, V clear, java.util.function.Supplier<T> factory) {
     T r = factory.get();
     execute(() -> switch (h.valueKind()) {
@@ -442,7 +471,7 @@ public abstract class AbstractFheType<
   }
 
   /// Deserialize from a [DynamicBuffer].
-  protected static <V, T extends AbstractFheType<V, T, ?>> T deserialize(
+  static <V, T extends AbstractFheType<V, T, ?>> T deserialize(
       FheTypeHandles<V> h, DynamicBuffer buf, ServerKey key, java.util.function.Supplier<T> factory) {
     T r = factory.get();
     execute(() -> h.lifecycle()
@@ -451,12 +480,15 @@ public abstract class AbstractFheType<
     return r;
   }
 
-  /// Evaluate a homomorphic if-then-else.
-  protected static <V, T extends AbstractFheType<V, T, ?>> T ifThenElse(
-      FheTypeHandles<V> h, FheBool condition, T thenVal, T elseVal, java.util.function.Supplier<T> factory) {
-    T r = factory.get();
-    execute(() -> h.misc().ifThenElse().apply(
-        condition.getValue(), thenVal.getValue(), elseVal.getValue(), r.getAddress()));
+  // ══════════════════════════════════════════════════════════════════════════
+  // FheConditional
+  // ══════════════════════════════════════════════════════════════════════════
+
+  @Override
+  public final T ifThenElse(FheBool condition, T elseValue) {
+    T r = newInstance();
+    execute(() -> handles().misc().ifThenElse().apply(
+        condition.getValue(), getValue(), elseValue.getValue(), r.getAddress()));
     return r;
   }
 

--- a/tfhe-java/src/main/java/io/github/rdlopes/tfhe/api/AbstractFheUnsignedInteger.java
+++ b/tfhe-java/src/main/java/io/github/rdlopes/tfhe/api/AbstractFheUnsignedInteger.java
@@ -21,12 +21,5 @@ public abstract class AbstractFheUnsignedInteger<
     super(destroyRef);
   }
 
-  /// `abs()` is not defined for unsigned integers — they are always ≥ 0.
-///
-/// @throws UnsupportedOperationException always
-  @Override
-  public final T abs() {
-    throw new UnsupportedOperationException(
-        "abs() is not defined for unsigned type " + getClass().getSimpleName());
-  }
+
 }

--- a/tfhe-java/src/main/java/io/github/rdlopes/tfhe/api/Fhe.java
+++ b/tfhe-java/src/main/java/io/github/rdlopes/tfhe/api/Fhe.java
@@ -1,0 +1,111 @@
+package io.github.rdlopes.tfhe.api;
+
+import io.github.rdlopes.tfhe.api.keys.ClientKey;
+import io.github.rdlopes.tfhe.api.keys.PublicKey;
+import io.github.rdlopes.tfhe.api.keys.ServerKey;
+import io.github.rdlopes.tfhe.api.serde.DynamicBuffer;
+import io.github.rdlopes.tfhe.api.types.FheBool;
+import io.github.rdlopes.tfhe.ffm.FheTypeHandles;
+import io.github.rdlopes.tfhe.ffm.NativeCall;
+import io.github.rdlopes.tfhe.ffm.NativePointer;
+import io.github.rdlopes.tfhe.utils.FheRegistry;
+
+/// Centralized entry-point and factory for FHE types.
+///
+/// This class provides type-safe factory methods to encrypt values and
+/// deserialize buffers. It delegates the operations to specific types
+/// using handles registered in [FheRegistry].
+public final class Fhe {
+
+  private Fhe() {
+    // Utility class
+  }
+
+  /// Encrypts a clear-text value using a client key.
+  @SuppressWarnings("unchecked")
+  public static <V, T extends FheType<V, T, ?>> T encrypt(V clearValue, ClientKey key, Class<T> targetClass) {
+    if (targetClass == FheBool.class) {
+      return (T) encryptBool((Boolean) clearValue, key);
+    }
+    return (T) delegateEncrypt(clearValue, key, (Class<? extends AbstractFheType<V, ?, ?>>) targetClass);
+  }
+
+  /// Encrypts a clear-text value using a public key.
+  @SuppressWarnings("unchecked")
+  public static <V, T extends FheType<V, T, ?>> T encrypt(V clearValue, PublicKey key, Class<T> targetClass) {
+    if (targetClass == FheBool.class) {
+      return (T) encryptBool((Boolean) clearValue, key);
+    }
+    return (T) delegateEncrypt(clearValue, key, (Class<? extends AbstractFheType<V, ?, ?>>) targetClass);
+  }
+
+  /// Encrypts a clear-text value trivially (without a key).
+  @SuppressWarnings("unchecked")
+  public static <V, T extends FheType<V, T, ?>> T encrypt(V clearValue, Class<T> targetClass) {
+    if (targetClass == FheBool.class) {
+      return (T) encryptBool((Boolean) clearValue);
+    }
+    return (T) delegateEncrypt(clearValue, (Class<? extends AbstractFheType<V, ?, ?>>) targetClass);
+  }
+
+  /// Deserializes an FHE type from a buffer using a server key.
+  @SuppressWarnings("unchecked")
+  public static <V, T extends FheType<V, T, ?>> T deserialize(DynamicBuffer buffer, ServerKey key, Class<T> targetClass) {
+    if (targetClass == FheBool.class) {
+      return (T) deserializeBool(buffer, key);
+    }
+    return (T) delegateDeserialize(buffer, key, (Class<? extends AbstractFheType<V, ?, ?>>) targetClass);
+  }
+
+  @SuppressWarnings("unchecked")
+  private static <V, T extends AbstractFheType<V, T, ?>> T delegateEncrypt(V clearValue, ClientKey key, Class<? extends AbstractFheType<V, ?, ?>> targetClass) {
+    FheTypeHandles<V> h = FheRegistry.getHandles(targetClass);
+    return AbstractFheType.encryptClientKey(h, clearValue, key, (java.util.function.Supplier<T>) FheRegistry.getFactory(targetClass));
+  }
+
+  @SuppressWarnings("unchecked")
+  private static <V, T extends AbstractFheType<V, T, ?>> T delegateEncrypt(V clearValue, PublicKey key, Class<? extends AbstractFheType<V, ?, ?>> targetClass) {
+    FheTypeHandles<V> h = FheRegistry.getHandles(targetClass);
+    return AbstractFheType.encryptPublicKey(h, clearValue, key, (java.util.function.Supplier<T>) FheRegistry.getFactory(targetClass));
+  }
+
+  @SuppressWarnings("unchecked")
+  private static <V, T extends AbstractFheType<V, T, ?>> T delegateEncrypt(V clearValue, Class<? extends AbstractFheType<V, ?, ?>> targetClass) {
+    FheTypeHandles<V> h = FheRegistry.getHandles(targetClass);
+    return AbstractFheType.encryptTrivial(h, clearValue, (java.util.function.Supplier<T>) FheRegistry.getFactory(targetClass));
+  }
+
+  @SuppressWarnings("unchecked")
+  private static <V, T extends AbstractFheType<V, T, ?>> T delegateDeserialize(DynamicBuffer buffer, ServerKey key, Class<? extends AbstractFheType<V, ?, ?>> targetClass) {
+    FheTypeHandles<V> h = FheRegistry.getHandles(targetClass);
+    return AbstractFheType.deserialize(h, buffer, key, (java.util.function.Supplier<T>) FheRegistry.getFactory(targetClass));
+  }
+
+  private static FheBool encryptBool(Boolean clearValue, ClientKey key) {
+    FheBool encrypted = FheBool.newEmpty();
+    NativeCall.execute(() -> io.github.rdlopes.tfhe.ffm.TfheHeader.fhe_bool_try_encrypt_with_client_key_bool(
+        clearValue, key.getValue(), encrypted.getAddress()));
+    return encrypted;
+  }
+
+  private static FheBool encryptBool(Boolean clearValue, PublicKey key) {
+    FheBool encrypted = FheBool.newEmpty();
+    NativeCall.execute(() -> io.github.rdlopes.tfhe.ffm.TfheHeader.fhe_bool_try_encrypt_with_public_key_bool(
+        clearValue, key.getValue(), encrypted.getAddress()));
+    return encrypted;
+  }
+
+  private static FheBool encryptBool(Boolean clearValue) {
+    FheBool encrypted = FheBool.newEmpty();
+    NativeCall.execute(() -> io.github.rdlopes.tfhe.ffm.TfheHeader.fhe_bool_try_encrypt_trivial_bool(
+        clearValue, encrypted.getAddress()));
+    return encrypted;
+  }
+
+  private static FheBool deserializeBool(DynamicBuffer buffer, ServerKey key) {
+    FheBool deserialized = FheBool.newEmpty();
+    NativeCall.execute(() -> io.github.rdlopes.tfhe.ffm.TfheHeader.fhe_bool_safe_deserialize_conformant(
+        buffer.getAddress(), DynamicBuffer.MAX_SERIALIZATION_SIZE, key.getValue(), deserialized.getAddress()));
+    return deserialized;
+  }
+}

--- a/tfhe-java/src/main/java/io/github/rdlopes/tfhe/api/FheConditional.java
+++ b/tfhe-java/src/main/java/io/github/rdlopes/tfhe/api/FheConditional.java
@@ -1,0 +1,7 @@
+package io.github.rdlopes.tfhe.api;
+
+import io.github.rdlopes.tfhe.api.types.FheBool;
+
+public interface FheConditional<T> {
+  T ifThenElse(FheBool condition, T elseValue);
+}

--- a/tfhe-java/src/main/java/io/github/rdlopes/tfhe/api/FheType.java
+++ b/tfhe-java/src/main/java/io/github/rdlopes/tfhe/api/FheType.java
@@ -1,7 +1,7 @@
 package io.github.rdlopes.tfhe.api;
 
 public interface FheType<V, T extends FheType<V, T, C>, C extends CompressedFheType<V, T, C>>
-  extends FheObject, FheCloneable<T>, FheLogic<V, T>, FheEquality<V, T> {
+  extends FheObject, FheCloneable<T>, FheLogic<V, T>, FheEquality<V, T>, FheConditional<T> {
 
   C compress();
 }

--- a/tfhe-java/src/main/java/io/github/rdlopes/tfhe/api/TfheThreadingContext.java
+++ b/tfhe-java/src/main/java/io/github/rdlopes/tfhe/api/TfheThreadingContext.java
@@ -15,6 +15,8 @@ import static io.github.rdlopes.tfhe.ffm.TfheHeader.*;
 public class TfheThreadingContext extends NativePointer implements AutoCloseable {
   private static final Logger logger = LoggerFactory.getLogger(TfheThreadingContext.class);
 
+  public static final ThreadLocal<Boolean> IN_THREADING_CONTEXT = ThreadLocal.withInitial(() -> false);
+
   public TfheThreadingContext(long numThreads) {
     super(context -> {
       tfhe_threading_context_destroy(context);
@@ -34,11 +36,14 @@ public class TfheThreadingContext extends NativePointer implements AutoCloseable
     try (Arena arena = Arena.ofConfined()) {
       MemorySegment stub = tfhe_threading_context_run$func.allocate(_ -> {
         try {
+          IN_THREADING_CONTEXT.set(true);
           task.run();
           return 0; // Success
         } catch (Exception e) {
           logger.error("Error running task in threading context", e);
           return 1; // Error
+        } finally {
+          IN_THREADING_CONTEXT.remove();
         }
       }, arena);
 

--- a/tfhe-java/src/main/java/io/github/rdlopes/tfhe/api/keys/CompressedServerKey.java
+++ b/tfhe-java/src/main/java/io/github/rdlopes/tfhe/api/keys/CompressedServerKey.java
@@ -4,6 +4,7 @@ import io.github.rdlopes.tfhe.api.CompressedFheKey;
 import io.github.rdlopes.tfhe.api.serde.DynamicBuffer;
 import io.github.rdlopes.tfhe.ffm.NativePointer;
 import io.github.rdlopes.tfhe.ffm.TfheHeader;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -11,44 +12,161 @@ import static io.github.rdlopes.tfhe.api.serde.DynamicBuffer.MAX_SERIALIZATION_S
 import static io.github.rdlopes.tfhe.ffm.NativeCall.execute;
 import static io.github.rdlopes.tfhe.ffm.TfheHeader.*;
 
+/// The canonical server key, shareable with remote servers and usable with both CPU and GPU.
+///
+/// `CompressedServerKey` is the pivot of the key architecture:
+/// from a single instance you can produce a CPU [ServerKey] (via [#decompress()]) or a
+/// GPU `CudaServerKey` (via [#decompressToGpu()]). It is the **only** key type that
+/// supports transparent GPU acceleration.
+///
+/// ## Activating the key — [#use()]
+///
+/// [#use()] is the single entry point for registering the key with the TFHE runtime.
+/// It always activates the CPU server key, and additionally activates the CUDA server key
+/// when the system property `tfhe.gpu=true` is set — all with lazy caching.
+///
+/// **Client side** (from a [KeySet]):
+///
+/// {@snippet lang=java :
+/// keySet.getCompressedServerKey().use();
+/// }
+///
+/// **Server side** (after receiving serialized bytes from the client):
+///
+/// {@snippet lang=java :
+/// CompressedServerKey serverKey = CompressedServerKey.deserialize(receivedBytes);
+/// serverKey.use(); // CPU, or CPU+GPU when -Dtfhe.gpu=true
+/// }
+///
+/// ## Serialization
+///
+/// Serialize this key to send it to a remote server. The server can then call [#use()]
+/// regardless of whether it uses CPU or GPU — no additional configuration needed beyond
+/// the `tfhe.gpu` system property.
+///
+/// {@snippet lang=java :
+/// // Client
+/// DynamicBuffer bytes = keySet.getCompressedServerKey().serialize();
+/// sendToServer(bytes);
+///
+/// // Server
+/// CompressedServerKey serverKey = CompressedServerKey.deserialize(bytes);
+/// serverKey.use();
+/// }
+///
+/// ## GPU note
+///
+/// This is the **only** key format that supports GPU activation.
+/// A [ServerKey] obtained from [ServerKey#deserialize(DynamicBuffer)] is always CPU-only.
+///
+/// @see KeySet the client-side key container
+/// @see io.github.rdlopes.tfhe.api.keys the package-level guide with full usage scenarios
 public class CompressedServerKey extends NativePointer implements CompressedFheKey<ServerKey> {
   private static final Logger logger = LoggerFactory.getLogger(CompressedServerKey.class);
 
+  /// Lazily-decompressed CPU key. Created on the first call to [#use()] or [#getCpuKey()].
+  private @Nullable ServerKey cpuKey;
+
+  /// Lazily-decompressed GPU key. Created on the first call to [#use()] when `tfhe.gpu=true`.
+  private @Nullable CudaServerKey cudaKey;
+
   CompressedServerKey() {
     logger.trace("init");
-
     super(TfheHeader::compressed_server_key_destroy);
   }
 
   public CompressedServerKey(ClientKey clientKey) {
-    logger.trace("init");
-
     this();
+    logger.trace("init - from ClientKey");
     execute(() -> compressed_server_key_new(clientKey.getValue(), getAddress()));
   }
 
+  /// Deserializes a [CompressedServerKey] from the given buffer.
+  ///
+  /// After deserialization, call [#use()] to activate the key for FHE operations.
   public static CompressedServerKey deserialize(DynamicBuffer dynamicBuffer) {
     logger.trace("deserialize - dynamicBuffer: {}", dynamicBuffer);
-
     CompressedServerKey deserialized = new CompressedServerKey();
     execute(() -> compressed_server_key_safe_deserialize(dynamicBuffer.getAddress(), MAX_SERIALIZATION_SIZE, deserialized.getAddress()));
     return deserialized;
   }
 
   @Override
+  public DynamicBuffer serialize() {
+    logger.trace("serialize");
+    DynamicBuffer dynamicBuffer = new DynamicBuffer();
+    execute(() -> compressed_server_key_safe_serialize(getValue(), dynamicBuffer.getAddress(), MAX_SERIALIZATION_SIZE));
+    return dynamicBuffer;
+  }
+
+  /// Decompresses this key into a new CPU [ServerKey].
+  /// Each call returns a fresh instance; the caller owns its lifecycle.
+  ///
+  /// For activating FHE operations, prefer [#use()] which also handles GPU.
+  @Override
   public ServerKey decompress() {
     logger.trace("decompress");
-
     return new ServerKey(this);
   }
 
+  /// Decompresses this key into a new GPU `CudaServerKey`.
+  /// Each call returns a fresh instance; the caller owns its lifecycle.
+  public CudaServerKey decompressToGpu() {
+    logger.trace("decompressToGpu");
+    CudaServerKey cuda = new CudaServerKey();
+    execute(() -> compressed_server_key_decompress_to_gpu(getValue(), cuda.getAddress()));
+    return cuda;
+  }
+
+  /// Registers this key with the TFHE runtime, transparently handling CPU and GPU.
+  ///
+  /// Always sets the CPU server key on the calling thread.
+  /// When `tfhe.gpu=true`, also initialises a dedicated GPU executor thread
+  /// (via [GpuRouter#initGpu(ServerKey, CudaServerKey)]) that has both CPU and CUDA
+  /// keys set — enabling GPU-accelerated operations without affecting CPU-only calls
+  /// on the calling thread.
+  ///
+  /// Both derived keys are cached lazily — decompression occurs only once.
+  public void use() {
+    logger.trace("use");
+    if (Boolean.getBoolean("tfhe.gpu")) {
+      // Delegate GPU key management to GpuRouter:
+      // - calling thread gets CPU key only
+      // - dedicated GPU executor thread gets CPU + CUDA keys
+      io.github.rdlopes.tfhe.ffm.GpuRouter.initGpu(getCpuKey().getValue(), getCudaKey().getValue());
+    } else {
+      execute(() -> set_server_key(getCpuKey().getValue()));
+    }
+  }
+
+  /// Returns the lazily-cached CPU [ServerKey].
+  /// Package-private so [KeySet] can expose it via [KeySet#getServerKey()]
+  /// without creating a duplicate object.
+  ServerKey getCpuKey() {
+    if (cpuKey == null) {
+      cpuKey = new ServerKey(this);
+    }
+    return cpuKey;
+  }
+
+  private CudaServerKey getCudaKey() {
+    if (cudaKey == null) {
+      cudaKey = decompressToGpu();
+    }
+    return cudaKey;
+  }
+
+  /// Destroys the cached CPU and GPU derived keys, then the compressed key itself.
   @Override
-  public DynamicBuffer serialize() {
-    logger.trace("serialize");
-
-    DynamicBuffer dynamicBuffer = new DynamicBuffer();
-    execute(() -> compressed_server_key_safe_serialize(getValue(), dynamicBuffer.getAddress(), MAX_SERIALIZATION_SIZE));
-
-    return dynamicBuffer;
+  public void destroy() {
+    if (cpuKey != null) {
+      cpuKey.destroy();
+      cpuKey = null;
+    }
+    if (cudaKey != null) {
+      cudaKey.destroy();
+      cudaKey = null;
+    }
+    super.destroy();
   }
 }

--- a/tfhe-java/src/main/java/io/github/rdlopes/tfhe/api/keys/CompressedServerKey.java
+++ b/tfhe-java/src/main/java/io/github/rdlopes/tfhe/api/keys/CompressedServerKey.java
@@ -39,9 +39,7 @@ public class CompressedServerKey extends NativePointer implements CompressedFheK
   public ServerKey decompress() {
     logger.trace("decompress");
 
-    ServerKey decompressed = new ServerKey();
-    execute(() -> compressed_server_key_decompress(getValue(), decompressed.getAddress()));
-    return decompressed;
+    return new ServerKey(this);
   }
 
   @Override

--- a/tfhe-java/src/main/java/io/github/rdlopes/tfhe/api/keys/CudaServerKey.java
+++ b/tfhe-java/src/main/java/io/github/rdlopes/tfhe/api/keys/CudaServerKey.java
@@ -1,0 +1,26 @@
+package io.github.rdlopes.tfhe.api.keys;
+
+import io.github.rdlopes.tfhe.ffm.NativePointer;
+import io.github.rdlopes.tfhe.ffm.TfheHeader;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static io.github.rdlopes.tfhe.ffm.NativeCall.execute;
+import static io.github.rdlopes.tfhe.ffm.TfheHeader.set_cuda_server_key;
+
+/// Package-private holder for a native `CudaServerKey*` pointer.
+/// Obtained via [CompressedServerKey#decompressToGpu()]; lifecycle is managed
+/// by the owning [CompressedServerKey] or the caller.
+final class CudaServerKey extends NativePointer {
+  private static final Logger logger = LoggerFactory.getLogger(CudaServerKey.class);
+
+  CudaServerKey() {
+    super(TfheHeader::cuda_server_key_destroy);
+  }
+
+  /// Registers this CUDA key with the TFHE runtime on the current thread.
+  void use() {
+    logger.trace("use");
+    execute(() -> set_cuda_server_key(getValue()));
+  }
+}

--- a/tfhe-java/src/main/java/io/github/rdlopes/tfhe/api/keys/KeySet.java
+++ b/tfhe-java/src/main/java/io/github/rdlopes/tfhe/api/keys/KeySet.java
@@ -57,6 +57,15 @@ public record KeySet(ClientKey clientKey, ServerKey serverKey) implements AutoCl
       ClientKey clientKey = new ClientKey();
       ServerKey serverKey = new ServerKey();
       config.initialize(clientKey, serverKey);
+
+      if (Boolean.getBoolean("tfhe.gpu")) {
+        CompressedServerKey compressed = new CompressedServerKey(clientKey);
+        ServerKey gpuServerKey = new ServerKey(compressed);
+        serverKey.destroy();
+        compressed.destroy();
+        return new KeySet(clientKey, gpuServerKey);
+      }
+
       return new KeySet(clientKey, serverKey);
     }
   }

--- a/tfhe-java/src/main/java/io/github/rdlopes/tfhe/api/keys/KeySet.java
+++ b/tfhe-java/src/main/java/io/github/rdlopes/tfhe/api/keys/KeySet.java
@@ -6,8 +6,62 @@ import org.slf4j.LoggerFactory;
 import static io.github.rdlopes.tfhe.ffm.NativeCall.execute;
 import static io.github.rdlopes.tfhe.ffm.TfheHeader.*;
 
-public record KeySet(ClientKey clientKey, ServerKey serverKey) implements AutoCloseable {
+/// Container for a complete FHE key set generated on the **client side**.
+/// Holds a [ClientKey] (always secret) and a [CompressedServerKey] (shareable with the server).
+///
+/// ## Typical usage — local computation
+///
+/// {@snippet lang=java :
+/// KeySet keySet = KeySet.builder()
+///     .useCustomParameters(CustomParameters.SHORTINT_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128)
+///     .build();
+///
+/// // Activate the server key (transparent CPU or CPU+GPU if -Dtfhe.gpu=true)
+/// keySet.getCompressedServerKey().use();
+///
+/// FheUint8 ct = FheUint8.encrypt((byte) 42, keySet.getClientKey());
+/// }
+///
+/// ## Sending the server key to a remote server
+///
+/// Serialize [CompressedServerKey] — **not** [ServerKey] — so that the server
+/// can activate GPU acceleration transparently:
+///
+/// {@snippet lang=java :
+/// DynamicBuffer bytes = keySet.getCompressedServerKey().serialize();
+/// sendToServer(bytes.toByteArray());
+/// }
+///
+/// ## Conformant ciphertext deserialization
+///
+/// When deserializing a ciphertext produced under this key set, pass the CPU
+/// [ServerKey] as the conformant key:
+///
+/// {@snippet lang=java :
+/// FheUint32 result = FheUint32.deserialize(buffer, keySet.getServerKey());
+/// }
+///
+/// ## GPU activation
+///
+/// No code change required — just add {@code -Dtfhe.gpu=true} to the JVM.
+/// [CompressedServerKey#use()] activates both the CPU and GPU keys automatically.
+///
+/// ## Lifecycle
+///
+/// Implements [AutoCloseable] — use in try-with-resources or call [#close()] explicitly.
+///
+/// @see CompressedServerKey the canonical server key and main entry point for key activation
+/// @see io.github.rdlopes.tfhe.api.keys the package-level guide with client/server scenarios
+public final class KeySet implements AutoCloseable {
   private static final Logger logger = LoggerFactory.getLogger(KeySet.class);
+
+  private final ClientKey clientKey;
+  private final CompressedServerKey compressedServerKey;
+
+  KeySet(ClientKey clientKey, CompressedServerKey compressedServerKey) {
+    this.clientKey = clientKey;
+    this.compressedServerKey = compressedServerKey;
+  }
 
   public static FheKeySetBuilder builder() {
     return new FheKeySetBuilder();
@@ -18,20 +72,40 @@ public record KeySet(ClientKey clientKey, ServerKey serverKey) implements AutoCl
     return clientKey;
   }
 
+  /// Returns the canonical [CompressedServerKey].
+  /// Call [CompressedServerKey#use()] on it to activate CPU and/or GPU keys for FHE operations.
+  ///
+  /// Use this method to:
+  /// - activate the server key: {@code keySet.getCompressedServerKey().use()}
+  /// - serialize and send to a remote server: {@code keySet.getCompressedServerKey().serialize()}
+  public CompressedServerKey getCompressedServerKey() {
+    logger.trace("getCompressedServerKey");
+    return compressedServerKey;
+  }
+
+  /// Returns the lazily-cached CPU [ServerKey] for use as a **conformant key** in
+  /// ciphertext deserialization.
+  ///
+  /// {@snippet lang=java :
+  /// FheUint32 result = FheUint32.deserialize(buffer, keySet.getServerKey());
+  /// }
+  ///
+  /// To **activate** the server key for FHE operations, prefer
+  /// [#getCompressedServerKey()].use() which also enables GPU if configured.
   public ServerKey getServerKey() {
     logger.trace("getServerKey");
-    return serverKey;
+    return compressedServerKey.getCpuKey();
   }
-  
-  /// Destroys both the client key and server key native resources.
-  /// Usable in try-with-resources for deterministic cleanup.
+
+  /// Destroys all native resources: the client key and the compressed server key
+  /// (which also destroys any cached CPU/GPU derived keys).
   @Override
   public void close() {
     logger.trace("close");
     clientKey.destroy();
-    serverKey.destroy();
+    compressedServerKey.destroy();
   }
-  
+
   public static class FheKeySetBuilder {
     private static final Logger logger = LoggerFactory.getLogger(FheKeySetBuilder.class);
     private final ConfigBuilder builder = new ConfigBuilder();
@@ -55,18 +129,15 @@ public record KeySet(ClientKey clientKey, ServerKey serverKey) implements AutoCl
       logger.trace("build");
       Config config = builder.build();
       ClientKey clientKey = new ClientKey();
-      ServerKey serverKey = new ServerKey();
-      config.initialize(clientKey, serverKey);
 
-      if (Boolean.getBoolean("tfhe.gpu")) {
-        CompressedServerKey compressed = new CompressedServerKey(clientKey);
-        ServerKey gpuServerKey = new ServerKey(compressed);
-        serverKey.destroy();
-        compressed.destroy();
-        return new KeySet(clientKey, gpuServerKey);
-      }
+      // generate_keys initialises the ClientKey (required by the native API).
+      // The ServerKey it also creates is discarded; CompressedServerKey becomes the canonical form.
+      ServerKey tempServerKey = new ServerKey();
+      config.initialize(clientKey, tempServerKey);
+      tempServerKey.destroy();
 
-      return new KeySet(clientKey, serverKey);
+      CompressedServerKey compressedServerKey = new CompressedServerKey(clientKey);
+      return new KeySet(clientKey, compressedServerKey);
     }
   }
 }

--- a/tfhe-java/src/main/java/io/github/rdlopes/tfhe/api/keys/ServerKey.java
+++ b/tfhe-java/src/main/java/io/github/rdlopes/tfhe/api/keys/ServerKey.java
@@ -13,11 +13,28 @@ import static io.github.rdlopes.tfhe.ffm.TfheHeader.*;
 
 public class ServerKey extends NativePointer implements FheKey {
   private static final Logger logger = LoggerFactory.getLogger(ServerKey.class);
+  private final boolean isGpu;
 
   ServerKey() {
-    logger.trace("init");
+    this(false);
+  }
 
-    super(TfheHeader::server_key_destroy);
+  ServerKey(boolean isGpu) {
+    logger.trace("init - isGpu: {}", isGpu);
+
+    super(isGpu ? TfheHeader::cuda_server_key_destroy : TfheHeader::server_key_destroy);
+    this.isGpu = isGpu;
+  }
+
+  public ServerKey(CompressedServerKey compressedServerKey) {
+    this(Boolean.getBoolean("tfhe.gpu"));
+    execute(() -> {
+      if (Boolean.getBoolean("tfhe.gpu")) {
+        return compressed_server_key_decompress_to_gpu(compressedServerKey.getValue(), getAddress());
+      } else {
+        return compressed_server_key_decompress(compressedServerKey.getValue(), getAddress());
+      }
+    });
   }
 
   public static ServerKey deserialize(DynamicBuffer dynamicBuffer) {
@@ -80,7 +97,11 @@ public class ServerKey extends NativePointer implements FheKey {
   public void use() {
     logger.trace("use");
 
-    execute(() -> set_server_key(getValue()));
+    if (isGpu) {
+      execute(() -> set_cuda_server_key(getValue()));
+    } else {
+      execute(() -> set_server_key(getValue()));
+    }
   }
 
   public void unset() {

--- a/tfhe-java/src/main/java/io/github/rdlopes/tfhe/api/keys/ServerKey.java
+++ b/tfhe-java/src/main/java/io/github/rdlopes/tfhe/api/keys/ServerKey.java
@@ -11,35 +11,66 @@ import static io.github.rdlopes.tfhe.api.serde.DynamicBuffer.MAX_SERIALIZATION_S
 import static io.github.rdlopes.tfhe.ffm.NativeCall.execute;
 import static io.github.rdlopes.tfhe.ffm.TfheHeader.*;
 
+/// A decompressed, CPU-only server key used to perform homomorphic operations.
+///
+/// ## When to use this class
+///
+/// Use `ServerKey` directly only in these two situations:
+///
+/// 1. **Conformant key for ciphertext deserialization** — pass it as the key parameter
+///    when deserializing ciphertexts produced under this key:
+///
+///    {@snippet lang=java :
+///    ServerKey serverKey = keySet.getServerKey();
+///    FheUint32 ct = FheUint32.deserialize(buffer, serverKey);
+///    }
+///
+/// 2. **CPU-only path after direct deserialization** — when you hold serialized
+///    `ServerKey` bytes (not `CompressedServerKey` bytes):
+///
+///    {@snippet lang=java :
+///    ServerKey serverKey = ServerKey.deserialize(buffer);
+///    serverKey.use(); // CPU only — GPU is not activated
+///    }
+///
+/// ## Prefer [CompressedServerKey] for key activation
+///
+/// For activating FHE operations (especially with GPU support), always prefer
+/// [CompressedServerKey#use()]:
+///
+/// {@snippet lang=java :
+/// // Activates CPU + GPU transparently based on -Dtfhe.gpu
+/// keySet.getCompressedServerKey().use();
+/// }
+///
+/// ## GPU note
+///
+/// `ServerKey` is **always CPU-only**, even when `tfhe.gpu=true`.
+/// For GPU support, use [CompressedServerKey#use()] or [CompressedServerKey#decompressToGpu()].
+///
+/// @see CompressedServerKey the canonical server key with transparent GPU support
 public class ServerKey extends NativePointer implements FheKey {
   private static final Logger logger = LoggerFactory.getLogger(ServerKey.class);
-  private final boolean isGpu;
 
   ServerKey() {
-    this(false);
+    logger.trace("init");
+    super(TfheHeader::server_key_destroy);
   }
 
-  ServerKey(boolean isGpu) {
-    logger.trace("init - isGpu: {}", isGpu);
-
-    super(isGpu ? TfheHeader::cuda_server_key_destroy : TfheHeader::server_key_destroy);
-    this.isGpu = isGpu;
+  /// Decompresses a [CompressedServerKey] into a CPU [ServerKey].
+  ServerKey(CompressedServerKey compressedServerKey) {
+    this();
+    logger.trace("init - from CompressedServerKey");
+    execute(() -> compressed_server_key_decompress(compressedServerKey.getValue(), getAddress()));
   }
 
-  public ServerKey(CompressedServerKey compressedServerKey) {
-    this(Boolean.getBoolean("tfhe.gpu"));
-    execute(() -> {
-      if (Boolean.getBoolean("tfhe.gpu")) {
-        return compressed_server_key_decompress_to_gpu(compressedServerKey.getValue(), getAddress());
-      } else {
-        return compressed_server_key_decompress(compressedServerKey.getValue(), getAddress());
-      }
-    });
-  }
-
+  /// Deserializes a CPU [ServerKey] from the given buffer.
+  ///
+  /// > **Note:** This method always produces a CPU-only key.
+  /// > For GPU support, serialize a [CompressedServerKey] on the client side and use
+  /// > `CompressedServerKey.deserialize(buffer).use()` on the server side.
   public static ServerKey deserialize(DynamicBuffer dynamicBuffer) {
     logger.trace("deserialize - dynamicBuffer: {}", dynamicBuffer);
-
     ServerKey deserialized = new ServerKey();
     execute(() -> server_key_safe_deserialize(dynamicBuffer.getAddress(), MAX_SERIALIZATION_SIZE, deserialized.getAddress()));
     return deserialized;
@@ -48,7 +79,6 @@ public class ServerKey extends NativePointer implements FheKey {
   @Override
   public DynamicBuffer serialize() {
     logger.trace("serialize");
-
     DynamicBuffer dynamicBuffer = new DynamicBuffer();
     execute(() -> server_key_safe_serialize(getValue(), dynamicBuffer.getAddress(), MAX_SERIALIZATION_SIZE));
     return dynamicBuffer;
@@ -56,10 +86,13 @@ public class ServerKey extends NativePointer implements FheKey {
 
   private static final ThreadLocal<ServerKey> CURRENT_KEY = new ThreadLocal<>();
 
+  /// Returns the [ServerKey] currently registered on this thread, or `null` if none.
   public static ServerKey current() {
     return CURRENT_KEY.get();
   }
 
+  /// Runs the given task with this key registered as the current server key,
+  /// then restores the previous key (if any) when the task completes.
   public void runWith(Runnable runnable) {
     ServerKey oldKey = CURRENT_KEY.get();
     CURRENT_KEY.set(this);
@@ -77,6 +110,11 @@ public class ServerKey extends NativePointer implements FheKey {
     }
   }
 
+  /// Calls the given task with this key registered as the current server key,
+  /// then restores the previous key (if any) when the task completes.
+  ///
+  /// @param <V> the return type of the callable
+  /// @return the value returned by the callable
   public <V> V callWith(java.util.concurrent.Callable<V> callable) throws Exception {
     ServerKey oldKey = CURRENT_KEY.get();
     CURRENT_KEY.set(this);
@@ -94,19 +132,17 @@ public class ServerKey extends NativePointer implements FheKey {
     }
   }
 
+  /// Registers this CPU key with the TFHE runtime on the current thread.
+  ///
+  /// For transparent CPU+GPU activation, use [CompressedServerKey#use()] instead.
   public void use() {
     logger.trace("use");
-
-    if (isGpu) {
-      execute(() -> set_cuda_server_key(getValue()));
-    } else {
-      execute(() -> set_server_key(getValue()));
-    }
+    execute(() -> set_server_key(getValue()));
   }
 
+  /// Unregisters the current server key from the TFHE runtime on this thread.
   public void unset() {
     logger.trace("unset");
-
     execute(TfheHeader::unset_server_key);
   }
 }

--- a/tfhe-java/src/main/java/io/github/rdlopes/tfhe/api/keys/package-info.java
+++ b/tfhe-java/src/main/java/io/github/rdlopes/tfhe/api/keys/package-info.java
@@ -1,0 +1,121 @@
+/// # FHE Key Management
+///
+/// This package contains all key types required for Fully Homomorphic Encryption (FHE) operations.
+/// Three roles are distinguished: **key generation**, **client-side computation**, and **server-side computation**.
+///
+/// ---
+///
+/// ## Key overview
+///
+/// | Class | Role | Shareable |
+/// |---|---|---|
+/// | [ClientKey] | Encryption and decryption — always kept secret | ❌ never |
+/// | [CompressedServerKey] | Canonical server key — CPU/GPU pivot | ✅ public |
+/// | [ServerKey] | Decompressed CPU view — conformant deserialization key | via [CompressedServerKey] |
+/// | [PublicKey] | Encryption without [ClientKey] | ✅ public |
+///
+/// ---
+///
+/// ## Scenario 1 — Local computation (client only)
+///
+/// The user generates keys and performs computations on the same machine.
+///
+/// {@snippet lang=java :
+/// // Generate keys
+/// KeySet keySet = KeySet.builder()
+///     .useCustomParameters(CustomParameters.SHORTINT_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128)
+///     .build();
+///
+/// // Activate the server key (CPU, or CPU+GPU when -Dtfhe.gpu=true)
+/// keySet.getCompressedServerKey().use();
+///
+/// // Encrypt, compute, decrypt
+/// FheUint8 a = FheUint8.encrypt((byte) 10, keySet.getClientKey());
+/// FheUint8 b = FheUint8.encrypt((byte) 20, keySet.getClientKey());
+/// FheUint8 sum = a.add(b);
+/// byte result = sum.decrypt(keySet.getClientKey()); // == 30
+/// }
+///
+/// ---
+///
+/// ## Scenario 2 — Client/Server architecture
+///
+/// The **client** generates keys, encrypts data, and sends the compressed server key.
+/// The **server** receives the key, activates it, and computes over ciphertexts without
+/// ever seeing data in the clear.
+///
+/// ### Client side
+///
+/// {@snippet lang=java :
+/// KeySet keySet = KeySet.builder().build();
+///
+/// // Serialize the CompressedServerKey and send it to the server
+/// DynamicBuffer serverKeyBytes = keySet.getCompressedServerKey().serialize();
+/// sendToServer(serverKeyBytes.toByteArray()); // network, file, etc.
+///
+/// // Encrypt the inputs and send them
+/// FheUint32 encrypted = FheUint32.encrypt(42, keySet.getClientKey());
+/// sendToServer(encrypted.serialize().toByteArray());
+/// }
+///
+/// ### Server side
+///
+/// {@snippet lang=java :
+/// // Deserialize and activate the server key
+/// CompressedServerKey serverKey = CompressedServerKey.deserialize(receivedKeyBuffer);
+/// serverKey.use(); // CPU, or CPU+GPU automatically when -Dtfhe.gpu=true
+///
+/// // Deserialize ciphertexts and compute
+/// FheUint32 a = FheUint32.deserialize(ciphertextBuffer, serverKey.decompress());
+/// FheUint32 b = FheUint32.deserialize(anotherBuffer,    serverKey.decompress());
+/// FheUint32 sum = a.add(b);
+///
+/// // Serialize and return the result
+/// sendToClient(sum.serialize().toByteArray());
+/// }
+///
+/// ### Client side — decrypting the result
+///
+/// {@snippet lang=java :
+/// FheUint32 result = FheUint32.deserialize(resultBuffer, keySet.getServerKey());
+/// int clearResult = result.decrypt(keySet.getClientKey()); // == 84
+/// }
+///
+/// ---
+///
+/// ## GPU activation
+///
+/// **No code changes required.** Simply pass the system property at JVM startup:
+///
+/// ```
+/// java -Dtfhe.gpu=true -jar my-app.jar
+/// ```
+///
+/// [CompressedServerKey#use()] then activates both engines automatically:
+/// the CPU key (required for ciphertext deserialization) and the GPU key
+/// (for accelerated homomorphic operations).
+///
+/// ---
+///
+/// ## CPU-only path — direct ServerKey deserialization
+///
+/// If you hold serialized bytes of a [ServerKey] (CPU binary format), you can
+/// deserialize them directly — but without GPU acceleration, even if `tfhe.gpu=true`:
+///
+/// {@snippet lang=java :
+/// // CPU-only, regardless of tfhe.gpu
+/// ServerKey serverKey = ServerKey.deserialize(buffer);
+/// serverKey.use();
+/// }
+///
+/// To benefit from GPU after deserialization, always serialize and transfer a
+/// [CompressedServerKey] (not a [ServerKey]):
+///
+/// {@snippet lang=java :
+/// // Client: serialize the CompressedServerKey
+/// keySet.getCompressedServerKey().serialize();
+///
+/// // Server: deserialize and activate with GPU support
+/// CompressedServerKey.deserialize(buffer).use(); // GPU activated if -Dtfhe.gpu=true
+/// }
+package io.github.rdlopes.tfhe.api.keys;

--- a/tfhe-java/src/main/java/io/github/rdlopes/tfhe/api/types/FheBool.java
+++ b/tfhe-java/src/main/java/io/github/rdlopes/tfhe/api/types/FheBool.java
@@ -1,7 +1,7 @@
 package io.github.rdlopes.tfhe.api.types;
 
+import io.github.rdlopes.tfhe.api.Fhe;
 import io.github.rdlopes.tfhe.utils.Generated;
-
 import io.github.rdlopes.tfhe.api.FheBoolean;
 import io.github.rdlopes.tfhe.api.keys.ClientKey;
 import io.github.rdlopes.tfhe.api.keys.PublicKey;
@@ -153,8 +153,13 @@ public class FheBool extends NativePointer implements FheBoolean<FheBool, Compre
     return result;
   }
 
+  @Override
+  public FheBool ifThenElse(FheBool condition, FheBool elseValue) {
+    return condition.bitAnd(this).bitOr(condition.bitNot().bitAnd(elseValue));
+  }
+
   public static FheBool ifThenElse(FheBool condition, FheBool thenValue, FheBool elseValue) {
-    return condition.bitAnd(thenValue).bitOr(condition.bitNot().bitAnd(elseValue));
+    return thenValue.ifThenElse(condition, elseValue);
   }
 
   @Override
@@ -186,27 +191,19 @@ public class FheBool extends NativePointer implements FheBoolean<FheBool, Compre
   }
 
   public static FheBool deserialize(DynamicBuffer dynamicBuffer, ServerKey serverKey) {
-    FheBool deserialized = new FheBool();
-    execute(() -> fhe_bool_safe_deserialize_conformant(dynamicBuffer.getAddress(), MAX_SERIALIZATION_SIZE, serverKey.getValue(), deserialized.getAddress()));
-    return deserialized;
+    return Fhe.deserialize(dynamicBuffer, serverKey, FheBool.class);
   }
 
   public static FheBool encrypt(Boolean clearValue, ClientKey clientKey) {
-    FheBool encrypted = new FheBool();
-    execute(() -> fhe_bool_try_encrypt_with_client_key_bool(clearValue, clientKey.getValue(), encrypted.getAddress()));
-    return encrypted;
+    return Fhe.encrypt(clearValue, clientKey, FheBool.class);
   }
 
   public static FheBool encrypt(Boolean clearValue, PublicKey publicKey) {
-    FheBool encrypted = new FheBool();
-    execute(() -> fhe_bool_try_encrypt_with_public_key_bool(clearValue, publicKey.getValue(), encrypted.getAddress()));
-    return encrypted;
+    return Fhe.encrypt(clearValue, publicKey, FheBool.class);
   }
 
   public static FheBool encrypt(Boolean clearValue) {
-    FheBool encrypted = new FheBool();
-    execute(() -> fhe_bool_try_encrypt_trivial_bool(clearValue, encrypted.getAddress()));
-    return encrypted;
+    return Fhe.encrypt(clearValue, FheBool.class);
   }
 
   @Override
@@ -241,8 +238,11 @@ public class FheBool extends NativePointer implements FheBoolean<FheBool, Compre
 
   @Override
   public CompressedFheBool compress() {
+    // compress() is not supported by the TFHE-rs CUDA backend — always use CPU.
     CompressedFheBool compressed = new CompressedFheBool();
-    execute(() -> H.compress.apply(getValue(), compressed.getAddress()));
+    io.github.rdlopes.tfhe.ffm.GpuRouter.execute(
+        io.github.rdlopes.tfhe.ffm.GpuRouter.Capability.CPU,
+        () -> H.compress.apply(getValue(), compressed.getAddress()));
     return compressed;
   }
 

--- a/tfhe-java/src/main/java/io/github/rdlopes/tfhe/api/types/FheInt128.java
+++ b/tfhe-java/src/main/java/io/github/rdlopes/tfhe/api/types/FheInt128.java
@@ -1,5 +1,7 @@
 package io.github.rdlopes.tfhe.api.types;
 
+import io.github.rdlopes.tfhe.api.Fhe;
+import io.github.rdlopes.tfhe.api.types.FheBool;
 import io.github.rdlopes.tfhe.utils.Generated;
 
 import io.github.rdlopes.tfhe.api.AbstractFheType;
@@ -22,10 +24,6 @@ import io.github.rdlopes.tfhe.utils.FheRegistry;
 @Generated
 public final class FheInt128 extends AbstractFheType<I128, FheInt128, CompressedFheInt128>
   implements FheSignedInteger<I128, FheInt128, CompressedFheInt128> {
-
-  static {
-    FheRegistry.registerFactory(FheInt128.class, FheInt128::new);
-  }
 
   static final FheTypeHandles<I128> HANDLES = new FheTypeHandles<>(
     new FheValueKind.Wide<>(I128::newEmpty),
@@ -116,6 +114,11 @@ public final class FheInt128 extends AbstractFheType<I128, FheInt128, Compressed
           TfheHeader::generate_oblivious_pseudo_random_bounded_fhe_int128,
           TfheHeader::fhe_int128_if_then_else));
 
+  static {
+    FheRegistry.registerFactory(FheInt128.class, FheInt128::new);
+    FheRegistry.registerHandles(FheInt128.class, HANDLES);
+  }
+
   FheInt128() { super(TfheHeader::fhe_int128_destroy); }
 
   @Override protected FheTypeHandles<I128> handles()      { return HANDLES; }
@@ -123,19 +126,24 @@ public final class FheInt128 extends AbstractFheType<I128, FheInt128, Compressed
   @Override protected CompressedFheInt128   newCompressed() { return new CompressedFheInt128(); }
 
   public static FheInt128 encrypt(I128 clearValue, ClientKey clientKey) {
-    return encryptClientKey(HANDLES, clearValue, clientKey, FheInt128::new);
+    return Fhe.encrypt(clearValue, clientKey, FheInt128.class);
   }
   public static FheInt128 encrypt(I128 clearValue, PublicKey publicKey) {
-    return encryptPublicKey(HANDLES, clearValue, publicKey, FheInt128::new);
+    return Fhe.encrypt(clearValue, publicKey, FheInt128.class);
   }
   public static FheInt128 encrypt(I128 clearValue) {
-    return encryptTrivial(HANDLES, clearValue, FheInt128::new);
+    return Fhe.encrypt(clearValue, FheInt128.class);
   }
   public static FheInt128 deserialize(DynamicBuffer buffer, ServerKey serverKey) {
-    return deserialize(HANDLES, buffer, serverKey, FheInt128::new);
+    return Fhe.deserialize(buffer, serverKey, FheInt128.class);
   }
   public static FheInt128 ifThenElse(FheBool condition, FheInt128 thenValue, FheInt128 elseValue) {
-    return ifThenElse(HANDLES, condition, thenValue, elseValue, FheInt128::new);
+    return thenValue.ifThenElse(condition, elseValue);
   }
 
+
+  @Override
+  public FheInt128 abs() {
+    return absImpl();
+  }
 }

--- a/tfhe-java/src/main/java/io/github/rdlopes/tfhe/api/types/FheInt8.java
+++ b/tfhe-java/src/main/java/io/github/rdlopes/tfhe/api/types/FheInt8.java
@@ -1,5 +1,7 @@
 package io.github.rdlopes.tfhe.api.types;
 
+import io.github.rdlopes.tfhe.api.Fhe;
+import io.github.rdlopes.tfhe.api.types.FheBool;
 import io.github.rdlopes.tfhe.utils.Generated;
 
 import io.github.rdlopes.tfhe.api.AbstractFheType;
@@ -21,10 +23,6 @@ import io.github.rdlopes.tfhe.utils.FheRegistry;
 @Generated
 public final class FheInt8 extends AbstractFheType<Byte, FheInt8, CompressedFheInt8>
   implements FheSignedInteger<Byte, FheInt8, CompressedFheInt8> {
-
-  static {
-    FheRegistry.registerFactory(FheInt8.class, FheInt8::new);
-  }
 
   // ── Static metadata — resolved once at class-loading via invokedynamic ──────
 
@@ -101,6 +99,11 @@ public final class FheInt8 extends AbstractFheType<Byte, FheInt8, CompressedFheI
 
   // ── Constructor (package-private — use static factories) ─────────────────────
 
+  static {
+    FheRegistry.registerFactory(FheInt8.class, FheInt8::new);
+    FheRegistry.registerHandles(FheInt8.class, HANDLES);
+  }
+
   FheInt8() {
     super(TfheHeader::fhe_int8_destroy);
   }
@@ -114,24 +117,29 @@ public final class FheInt8 extends AbstractFheType<Byte, FheInt8, CompressedFheI
   // ── Static factories ──────────────────────────────────────────────────────────
 
   public static FheInt8 encrypt(Byte clearValue, ClientKey clientKey) {
-    return encryptClientKey(HANDLES, clearValue, clientKey, FheInt8::new);
+    return Fhe.encrypt(clearValue, clientKey, FheInt8.class);
   }
 
   public static FheInt8 encrypt(Byte clearValue, PublicKey publicKey) {
-    return encryptPublicKey(HANDLES, clearValue, publicKey, FheInt8::new);
+    return Fhe.encrypt(clearValue, publicKey, FheInt8.class);
   }
 
   public static FheInt8 encrypt(Byte clearValue) {
-    return encryptTrivial(HANDLES, clearValue, FheInt8::new);
+    return Fhe.encrypt(clearValue, FheInt8.class);
   }
 
   public static FheInt8 deserialize(DynamicBuffer buffer, ServerKey serverKey) {
-    return deserialize(HANDLES, buffer, serverKey, FheInt8::new);
+    return Fhe.deserialize(buffer, serverKey, FheInt8.class);
   }
 
   public static FheInt8 ifThenElse(FheBool condition, FheInt8 thenValue, FheInt8 elseValue) {
-    return ifThenElse(HANDLES, condition, thenValue, elseValue, FheInt8::new);
+    return thenValue.ifThenElse(condition, elseValue);
   }
 
 
+
+  @Override
+  public FheInt8 abs() {
+    return absImpl();
+  }
 }

--- a/tfhe-java/src/main/java/io/github/rdlopes/tfhe/api/types/FheUint128.java
+++ b/tfhe-java/src/main/java/io/github/rdlopes/tfhe/api/types/FheUint128.java
@@ -1,5 +1,7 @@
 package io.github.rdlopes.tfhe.api.types;
 
+import io.github.rdlopes.tfhe.api.Fhe;
+import io.github.rdlopes.tfhe.api.types.FheBool;
 import io.github.rdlopes.tfhe.utils.Generated;
 
 import io.github.rdlopes.tfhe.api.AbstractFheType;
@@ -23,10 +25,6 @@ import io.github.rdlopes.tfhe.utils.FheRegistry;
 @Generated
 public final class FheUint128 extends AbstractFheUnsignedInteger<U128, FheUint128, CompressedFheUint128>
     implements FheUnsignedInteger<U128, FheUint128, CompressedFheUint128> {
-
-  static {
-    FheRegistry.registerFactory(FheUint128.class, FheUint128::new);
-  }
 
   static final FheTypeHandles<U128> HANDLES = new FheTypeHandles<>(
     new FheValueKind.Wide<>(U128::newEmpty),
@@ -117,6 +115,11 @@ public final class FheUint128 extends AbstractFheUnsignedInteger<U128, FheUint12
           TfheHeader::generate_oblivious_pseudo_random_bounded_fhe_uint128,
           TfheHeader::fhe_uint128_if_then_else));
 
+  static {
+    FheRegistry.registerFactory(FheUint128.class, FheUint128::new);
+    FheRegistry.registerHandles(FheUint128.class, HANDLES);
+  }
+
   FheUint128() { super(TfheHeader::fhe_uint128_destroy); }
 
   @Override protected FheTypeHandles<U128> handles()      { return HANDLES; }
@@ -124,19 +127,19 @@ public final class FheUint128 extends AbstractFheUnsignedInteger<U128, FheUint12
   @Override protected CompressedFheUint128   newCompressed() { return new CompressedFheUint128(); }
 
   public static FheUint128 encrypt(U128 clearValue, ClientKey clientKey) {
-    return encryptClientKey(HANDLES, clearValue, clientKey, FheUint128::new);
+    return Fhe.encrypt(clearValue, clientKey, FheUint128.class);
   }
   public static FheUint128 encrypt(U128 clearValue, PublicKey publicKey) {
-    return encryptPublicKey(HANDLES, clearValue, publicKey, FheUint128::new);
+    return Fhe.encrypt(clearValue, publicKey, FheUint128.class);
   }
   public static FheUint128 encrypt(U128 clearValue) {
-    return encryptTrivial(HANDLES, clearValue, FheUint128::new);
+    return Fhe.encrypt(clearValue, FheUint128.class);
   }
   public static FheUint128 deserialize(DynamicBuffer buffer, ServerKey serverKey) {
-    return deserialize(HANDLES, buffer, serverKey, FheUint128::new);
+    return Fhe.deserialize(buffer, serverKey, FheUint128.class);
   }
   public static FheUint128 ifThenElse(FheBool condition, FheUint128 thenValue, FheUint128 elseValue) {
-    return ifThenElse(HANDLES, condition, thenValue, elseValue, FheUint128::new);
+    return thenValue.ifThenElse(condition, elseValue);
   }
 
 }

--- a/tfhe-java/src/main/java/io/github/rdlopes/tfhe/api/types/FheUint8.java
+++ b/tfhe-java/src/main/java/io/github/rdlopes/tfhe/api/types/FheUint8.java
@@ -3,11 +3,13 @@ package io.github.rdlopes.tfhe.api.types;
 import io.github.rdlopes.tfhe.utils.Generated;
 
 import io.github.rdlopes.tfhe.api.AbstractFheUnsignedInteger;
+import io.github.rdlopes.tfhe.api.Fhe;
 import io.github.rdlopes.tfhe.api.FheUnsignedInteger;
 import io.github.rdlopes.tfhe.api.keys.ClientKey;
 import io.github.rdlopes.tfhe.api.keys.PublicKey;
 import io.github.rdlopes.tfhe.api.keys.ServerKey;
 import io.github.rdlopes.tfhe.api.serde.DynamicBuffer;
+import io.github.rdlopes.tfhe.api.types.FheBool;
 import io.github.rdlopes.tfhe.ffm.FheTypeHandles;
 import io.github.rdlopes.tfhe.ffm.FheValueKind;
 import io.github.rdlopes.tfhe.ffm.TfheHeader;
@@ -17,10 +19,6 @@ import io.github.rdlopes.tfhe.utils.FheRegistry;
 @Generated
 public final class FheUint8 extends AbstractFheUnsignedInteger<Byte, FheUint8, CompressedFheUint8>
     implements FheUnsignedInteger<Byte, FheUint8, CompressedFheUint8> {
-
-  static {
-    FheRegistry.registerFactory(FheUint8.class, FheUint8::new);
-  }
 
   static final FheTypeHandles<Byte> HANDLES = new FheTypeHandles<>(
       FheValueKind.BYTE,
@@ -93,6 +91,11 @@ public final class FheUint8 extends AbstractFheUnsignedInteger<Byte, FheUint8, C
           TfheHeader::generate_oblivious_pseudo_random_bounded_fhe_uint8,
           TfheHeader::fhe_uint8_if_then_else));
 
+  static {
+    FheRegistry.registerFactory(FheUint8.class, FheUint8::new);
+    FheRegistry.registerHandles(FheUint8.class, HANDLES);
+  }
+
   FheUint8() {
     super(TfheHeader::fhe_uint8_destroy);
   }
@@ -102,23 +105,23 @@ public final class FheUint8 extends AbstractFheUnsignedInteger<Byte, FheUint8, C
   @Override protected CompressedFheUint8   newCompressed() { return new CompressedFheUint8(); }
 
   public static FheUint8 encrypt(Byte clearValue, ClientKey clientKey) {
-    return encryptClientKey(HANDLES, clearValue, clientKey, FheUint8::new);
+    return Fhe.encrypt(clearValue, clientKey, FheUint8.class);
   }
 
   public static FheUint8 encrypt(Byte clearValue, PublicKey publicKey) {
-    return encryptPublicKey(HANDLES, clearValue, publicKey, FheUint8::new);
+    return Fhe.encrypt(clearValue, publicKey, FheUint8.class);
   }
 
   public static FheUint8 encrypt(Byte clearValue) {
-    return encryptTrivial(HANDLES, clearValue, FheUint8::new);
+    return Fhe.encrypt(clearValue, FheUint8.class);
   }
 
   public static FheUint8 deserialize(DynamicBuffer buffer, ServerKey serverKey) {
-    return deserialize(HANDLES, buffer, serverKey, FheUint8::new);
+    return Fhe.deserialize(buffer, serverKey, FheUint8.class);
   }
 
   public static FheUint8 ifThenElse(FheBool condition, FheUint8 thenValue, FheUint8 elseValue) {
-    return ifThenElse(HANDLES, condition, thenValue, elseValue, FheUint8::new);
+    return thenValue.ifThenElse(condition, elseValue);
   }
 
 }

--- a/tfhe-java/src/main/java/io/github/rdlopes/tfhe/api/types/extended/FheInt10.java
+++ b/tfhe-java/src/main/java/io/github/rdlopes/tfhe/api/types/extended/FheInt10.java
@@ -3,6 +3,9 @@ package io.github.rdlopes.tfhe.api.types.extended;
 import io.github.rdlopes.tfhe.api.types.*;
 import io.github.rdlopes.tfhe.utils.Generated;
 
+import io.github.rdlopes.tfhe.api.Fhe;
+import io.github.rdlopes.tfhe.api.types.FheBool;
+
 import io.github.rdlopes.tfhe.api.AbstractFheType;
 import io.github.rdlopes.tfhe.api.FheSignedInteger;
 import io.github.rdlopes.tfhe.api.keys.ClientKey;
@@ -17,10 +20,6 @@ import io.github.rdlopes.tfhe.utils.FheRegistry;
 @Generated
 public final class FheInt10 extends AbstractFheType<Short, FheInt10, CompressedFheInt10>
   implements FheSignedInteger<Short, FheInt10, CompressedFheInt10> {
-
-  static {
-    FheRegistry.registerFactory(FheInt10.class, FheInt10::new);
-  }
 
   static final FheTypeHandles<Short> HANDLES = new FheTypeHandles<>(
       FheValueKind.SHORT,
@@ -93,6 +92,11 @@ public final class FheInt10 extends AbstractFheType<Short, FheInt10, CompressedF
           TfheHeader::generate_oblivious_pseudo_random_bounded_fhe_int10,
           TfheHeader::fhe_int10_if_then_else));
 
+  static {
+    FheRegistry.registerFactory(FheInt10.class, FheInt10::new);
+    FheRegistry.registerHandles(FheInt10.class, HANDLES);
+  }
+
   FheInt10() { super(TfheHeader::fhe_int10_destroy); }
 
   @Override protected FheTypeHandles<Short> handles()      { return HANDLES; }
@@ -100,19 +104,24 @@ public final class FheInt10 extends AbstractFheType<Short, FheInt10, CompressedF
   @Override protected CompressedFheInt10   newCompressed() { return new CompressedFheInt10(); }
 
   public static FheInt10 encrypt(Short clearValue, ClientKey clientKey) {
-    return encryptClientKey(HANDLES, clearValue, clientKey, FheInt10::new);
+    return Fhe.encrypt(clearValue, clientKey, FheInt10.class);
   }
   public static FheInt10 encrypt(Short clearValue, PublicKey publicKey) {
-    return encryptPublicKey(HANDLES, clearValue, publicKey, FheInt10::new);
+    return Fhe.encrypt(clearValue, publicKey, FheInt10.class);
   }
   public static FheInt10 encrypt(Short clearValue) {
-    return encryptTrivial(HANDLES, clearValue, FheInt10::new);
+    return Fhe.encrypt(clearValue, FheInt10.class);
   }
   public static FheInt10 deserialize(DynamicBuffer buffer, ServerKey serverKey) {
-    return deserialize(HANDLES, buffer, serverKey, FheInt10::new);
+    return Fhe.deserialize(buffer, serverKey, FheInt10.class);
   }
   public static FheInt10 ifThenElse(FheBool condition, FheInt10 thenValue, FheInt10 elseValue) {
-    return ifThenElse(HANDLES, condition, thenValue, elseValue, FheInt10::new);
+    return thenValue.ifThenElse(condition, elseValue);
   }
 
+
+  @Override
+  public FheInt10 abs() {
+    return absImpl();
+  }
 }

--- a/tfhe-java/src/main/java/io/github/rdlopes/tfhe/api/types/extended/FheInt1024.java
+++ b/tfhe-java/src/main/java/io/github/rdlopes/tfhe/api/types/extended/FheInt1024.java
@@ -3,6 +3,9 @@ package io.github.rdlopes.tfhe.api.types.extended;
 import io.github.rdlopes.tfhe.api.types.*;
 import io.github.rdlopes.tfhe.utils.Generated;
 
+import io.github.rdlopes.tfhe.api.Fhe;
+import io.github.rdlopes.tfhe.api.types.FheBool;
+
 import io.github.rdlopes.tfhe.api.AbstractFheType;
 import io.github.rdlopes.tfhe.api.FheSignedInteger;
 import io.github.rdlopes.tfhe.api.keys.ClientKey;
@@ -23,10 +26,6 @@ import io.github.rdlopes.tfhe.utils.FheRegistry;
 @Generated
 public final class FheInt1024 extends AbstractFheType<I1024, FheInt1024, CompressedFheInt1024>
   implements FheSignedInteger<I1024, FheInt1024, CompressedFheInt1024> {
-
-  static {
-    FheRegistry.registerFactory(FheInt1024.class, FheInt1024::new);
-  }
 
   static final FheTypeHandles<I1024> HANDLES = new FheTypeHandles<>(
     new FheValueKind.Wide<>(I1024::newEmpty),
@@ -117,6 +116,11 @@ public final class FheInt1024 extends AbstractFheType<I1024, FheInt1024, Compres
           TfheHeader::generate_oblivious_pseudo_random_bounded_fhe_int1024,
           TfheHeader::fhe_int1024_if_then_else));
 
+  static {
+    FheRegistry.registerFactory(FheInt1024.class, FheInt1024::new);
+    FheRegistry.registerHandles(FheInt1024.class, HANDLES);
+  }
+
   FheInt1024() { super(TfheHeader::fhe_int1024_destroy); }
 
   @Override protected FheTypeHandles<I1024> handles()      { return HANDLES; }
@@ -124,19 +128,24 @@ public final class FheInt1024 extends AbstractFheType<I1024, FheInt1024, Compres
   @Override protected CompressedFheInt1024   newCompressed() { return new CompressedFheInt1024(); }
 
   public static FheInt1024 encrypt(I1024 clearValue, ClientKey clientKey) {
-    return encryptClientKey(HANDLES, clearValue, clientKey, FheInt1024::new);
+    return Fhe.encrypt(clearValue, clientKey, FheInt1024.class);
   }
   public static FheInt1024 encrypt(I1024 clearValue, PublicKey publicKey) {
-    return encryptPublicKey(HANDLES, clearValue, publicKey, FheInt1024::new);
+    return Fhe.encrypt(clearValue, publicKey, FheInt1024.class);
   }
   public static FheInt1024 encrypt(I1024 clearValue) {
-    return encryptTrivial(HANDLES, clearValue, FheInt1024::new);
+    return Fhe.encrypt(clearValue, FheInt1024.class);
   }
   public static FheInt1024 deserialize(DynamicBuffer buffer, ServerKey serverKey) {
-    return deserialize(HANDLES, buffer, serverKey, FheInt1024::new);
+    return Fhe.deserialize(buffer, serverKey, FheInt1024.class);
   }
   public static FheInt1024 ifThenElse(FheBool condition, FheInt1024 thenValue, FheInt1024 elseValue) {
-    return ifThenElse(HANDLES, condition, thenValue, elseValue, FheInt1024::new);
+    return thenValue.ifThenElse(condition, elseValue);
   }
 
+
+  @Override
+  public FheInt1024 abs() {
+    return absImpl();
+  }
 }

--- a/tfhe-java/src/main/java/io/github/rdlopes/tfhe/api/types/extended/FheInt12.java
+++ b/tfhe-java/src/main/java/io/github/rdlopes/tfhe/api/types/extended/FheInt12.java
@@ -3,6 +3,9 @@ package io.github.rdlopes.tfhe.api.types.extended;
 import io.github.rdlopes.tfhe.api.types.*;
 import io.github.rdlopes.tfhe.utils.Generated;
 
+import io.github.rdlopes.tfhe.api.Fhe;
+import io.github.rdlopes.tfhe.api.types.FheBool;
+
 import io.github.rdlopes.tfhe.api.AbstractFheType;
 import io.github.rdlopes.tfhe.api.FheSignedInteger;
 import io.github.rdlopes.tfhe.api.keys.ClientKey;
@@ -17,10 +20,6 @@ import io.github.rdlopes.tfhe.utils.FheRegistry;
 @Generated
 public final class FheInt12 extends AbstractFheType<Short, FheInt12, CompressedFheInt12>
   implements FheSignedInteger<Short, FheInt12, CompressedFheInt12> {
-
-  static {
-    FheRegistry.registerFactory(FheInt12.class, FheInt12::new);
-  }
 
   static final FheTypeHandles<Short> HANDLES = new FheTypeHandles<>(
       FheValueKind.SHORT,
@@ -93,6 +92,11 @@ public final class FheInt12 extends AbstractFheType<Short, FheInt12, CompressedF
           TfheHeader::generate_oblivious_pseudo_random_bounded_fhe_int12,
           TfheHeader::fhe_int12_if_then_else));
 
+  static {
+    FheRegistry.registerFactory(FheInt12.class, FheInt12::new);
+    FheRegistry.registerHandles(FheInt12.class, HANDLES);
+  }
+
   FheInt12() { super(TfheHeader::fhe_int12_destroy); }
 
   @Override protected FheTypeHandles<Short> handles()      { return HANDLES; }
@@ -100,19 +104,24 @@ public final class FheInt12 extends AbstractFheType<Short, FheInt12, CompressedF
   @Override protected CompressedFheInt12   newCompressed() { return new CompressedFheInt12(); }
 
   public static FheInt12 encrypt(Short clearValue, ClientKey clientKey) {
-    return encryptClientKey(HANDLES, clearValue, clientKey, FheInt12::new);
+    return Fhe.encrypt(clearValue, clientKey, FheInt12.class);
   }
   public static FheInt12 encrypt(Short clearValue, PublicKey publicKey) {
-    return encryptPublicKey(HANDLES, clearValue, publicKey, FheInt12::new);
+    return Fhe.encrypt(clearValue, publicKey, FheInt12.class);
   }
   public static FheInt12 encrypt(Short clearValue) {
-    return encryptTrivial(HANDLES, clearValue, FheInt12::new);
+    return Fhe.encrypt(clearValue, FheInt12.class);
   }
   public static FheInt12 deserialize(DynamicBuffer buffer, ServerKey serverKey) {
-    return deserialize(HANDLES, buffer, serverKey, FheInt12::new);
+    return Fhe.deserialize(buffer, serverKey, FheInt12.class);
   }
   public static FheInt12 ifThenElse(FheBool condition, FheInt12 thenValue, FheInt12 elseValue) {
-    return ifThenElse(HANDLES, condition, thenValue, elseValue, FheInt12::new);
+    return thenValue.ifThenElse(condition, elseValue);
   }
 
+
+  @Override
+  public FheInt12 abs() {
+    return absImpl();
+  }
 }

--- a/tfhe-java/src/main/java/io/github/rdlopes/tfhe/api/types/extended/FheInt14.java
+++ b/tfhe-java/src/main/java/io/github/rdlopes/tfhe/api/types/extended/FheInt14.java
@@ -3,6 +3,9 @@ package io.github.rdlopes.tfhe.api.types.extended;
 import io.github.rdlopes.tfhe.api.types.*;
 import io.github.rdlopes.tfhe.utils.Generated;
 
+import io.github.rdlopes.tfhe.api.Fhe;
+import io.github.rdlopes.tfhe.api.types.FheBool;
+
 import io.github.rdlopes.tfhe.api.AbstractFheType;
 import io.github.rdlopes.tfhe.api.FheSignedInteger;
 import io.github.rdlopes.tfhe.api.keys.ClientKey;
@@ -17,10 +20,6 @@ import io.github.rdlopes.tfhe.utils.FheRegistry;
 @Generated
 public final class FheInt14 extends AbstractFheType<Short, FheInt14, CompressedFheInt14>
   implements FheSignedInteger<Short, FheInt14, CompressedFheInt14> {
-
-  static {
-    FheRegistry.registerFactory(FheInt14.class, FheInt14::new);
-  }
 
   static final FheTypeHandles<Short> HANDLES = new FheTypeHandles<>(
       FheValueKind.SHORT,
@@ -93,6 +92,11 @@ public final class FheInt14 extends AbstractFheType<Short, FheInt14, CompressedF
           TfheHeader::generate_oblivious_pseudo_random_bounded_fhe_int14,
           TfheHeader::fhe_int14_if_then_else));
 
+  static {
+    FheRegistry.registerFactory(FheInt14.class, FheInt14::new);
+    FheRegistry.registerHandles(FheInt14.class, HANDLES);
+  }
+
   FheInt14() { super(TfheHeader::fhe_int14_destroy); }
 
   @Override protected FheTypeHandles<Short> handles()      { return HANDLES; }
@@ -100,19 +104,24 @@ public final class FheInt14 extends AbstractFheType<Short, FheInt14, CompressedF
   @Override protected CompressedFheInt14   newCompressed() { return new CompressedFheInt14(); }
 
   public static FheInt14 encrypt(Short clearValue, ClientKey clientKey) {
-    return encryptClientKey(HANDLES, clearValue, clientKey, FheInt14::new);
+    return Fhe.encrypt(clearValue, clientKey, FheInt14.class);
   }
   public static FheInt14 encrypt(Short clearValue, PublicKey publicKey) {
-    return encryptPublicKey(HANDLES, clearValue, publicKey, FheInt14::new);
+    return Fhe.encrypt(clearValue, publicKey, FheInt14.class);
   }
   public static FheInt14 encrypt(Short clearValue) {
-    return encryptTrivial(HANDLES, clearValue, FheInt14::new);
+    return Fhe.encrypt(clearValue, FheInt14.class);
   }
   public static FheInt14 deserialize(DynamicBuffer buffer, ServerKey serverKey) {
-    return deserialize(HANDLES, buffer, serverKey, FheInt14::new);
+    return Fhe.deserialize(buffer, serverKey, FheInt14.class);
   }
   public static FheInt14 ifThenElse(FheBool condition, FheInt14 thenValue, FheInt14 elseValue) {
-    return ifThenElse(HANDLES, condition, thenValue, elseValue, FheInt14::new);
+    return thenValue.ifThenElse(condition, elseValue);
   }
 
+
+  @Override
+  public FheInt14 abs() {
+    return absImpl();
+  }
 }

--- a/tfhe-java/src/main/java/io/github/rdlopes/tfhe/api/types/extended/FheInt16.java
+++ b/tfhe-java/src/main/java/io/github/rdlopes/tfhe/api/types/extended/FheInt16.java
@@ -3,6 +3,9 @@ package io.github.rdlopes.tfhe.api.types.extended;
 import io.github.rdlopes.tfhe.api.types.*;
 import io.github.rdlopes.tfhe.utils.Generated;
 
+import io.github.rdlopes.tfhe.api.Fhe;
+import io.github.rdlopes.tfhe.api.types.FheBool;
+
 import io.github.rdlopes.tfhe.api.AbstractFheType;
 import io.github.rdlopes.tfhe.api.FheSignedInteger;
 import io.github.rdlopes.tfhe.api.keys.ClientKey;
@@ -17,10 +20,6 @@ import io.github.rdlopes.tfhe.utils.FheRegistry;
 @Generated
 public final class FheInt16 extends AbstractFheType<Short, FheInt16, CompressedFheInt16>
   implements FheSignedInteger<Short, FheInt16, CompressedFheInt16> {
-
-  static {
-    FheRegistry.registerFactory(FheInt16.class, FheInt16::new);
-  }
 
   static final FheTypeHandles<Short> HANDLES = new FheTypeHandles<>(
       FheValueKind.SHORT,
@@ -93,6 +92,11 @@ public final class FheInt16 extends AbstractFheType<Short, FheInt16, CompressedF
           TfheHeader::generate_oblivious_pseudo_random_bounded_fhe_int16,
           TfheHeader::fhe_int16_if_then_else));
 
+  static {
+    FheRegistry.registerFactory(FheInt16.class, FheInt16::new);
+    FheRegistry.registerHandles(FheInt16.class, HANDLES);
+  }
+
   FheInt16() { super(TfheHeader::fhe_int16_destroy); }
 
   @Override protected FheTypeHandles<Short> handles()      { return HANDLES; }
@@ -100,19 +104,24 @@ public final class FheInt16 extends AbstractFheType<Short, FheInt16, CompressedF
   @Override protected CompressedFheInt16   newCompressed() { return new CompressedFheInt16(); }
 
   public static FheInt16 encrypt(Short clearValue, ClientKey clientKey) {
-    return encryptClientKey(HANDLES, clearValue, clientKey, FheInt16::new);
+    return Fhe.encrypt(clearValue, clientKey, FheInt16.class);
   }
   public static FheInt16 encrypt(Short clearValue, PublicKey publicKey) {
-    return encryptPublicKey(HANDLES, clearValue, publicKey, FheInt16::new);
+    return Fhe.encrypt(clearValue, publicKey, FheInt16.class);
   }
   public static FheInt16 encrypt(Short clearValue) {
-    return encryptTrivial(HANDLES, clearValue, FheInt16::new);
+    return Fhe.encrypt(clearValue, FheInt16.class);
   }
   public static FheInt16 deserialize(DynamicBuffer buffer, ServerKey serverKey) {
-    return deserialize(HANDLES, buffer, serverKey, FheInt16::new);
+    return Fhe.deserialize(buffer, serverKey, FheInt16.class);
   }
   public static FheInt16 ifThenElse(FheBool condition, FheInt16 thenValue, FheInt16 elseValue) {
-    return ifThenElse(HANDLES, condition, thenValue, elseValue, FheInt16::new);
+    return thenValue.ifThenElse(condition, elseValue);
   }
 
+
+  @Override
+  public FheInt16 abs() {
+    return absImpl();
+  }
 }

--- a/tfhe-java/src/main/java/io/github/rdlopes/tfhe/api/types/extended/FheInt160.java
+++ b/tfhe-java/src/main/java/io/github/rdlopes/tfhe/api/types/extended/FheInt160.java
@@ -3,6 +3,9 @@ package io.github.rdlopes.tfhe.api.types.extended;
 import io.github.rdlopes.tfhe.api.types.*;
 import io.github.rdlopes.tfhe.utils.Generated;
 
+import io.github.rdlopes.tfhe.api.Fhe;
+import io.github.rdlopes.tfhe.api.types.FheBool;
+
 import io.github.rdlopes.tfhe.api.AbstractFheType;
 import io.github.rdlopes.tfhe.api.FheSignedInteger;
 import io.github.rdlopes.tfhe.api.keys.ClientKey;
@@ -23,10 +26,6 @@ import io.github.rdlopes.tfhe.utils.FheRegistry;
 @Generated
 public final class FheInt160 extends AbstractFheType<I256, FheInt160, CompressedFheInt160>
   implements FheSignedInteger<I256, FheInt160, CompressedFheInt160> {
-
-  static {
-    FheRegistry.registerFactory(FheInt160.class, FheInt160::new);
-  }
 
   static final FheTypeHandles<I256> HANDLES = new FheTypeHandles<>(
     new FheValueKind.Wide<>(I256::newEmpty),
@@ -117,6 +116,11 @@ public final class FheInt160 extends AbstractFheType<I256, FheInt160, Compressed
           TfheHeader::generate_oblivious_pseudo_random_bounded_fhe_int160,
           TfheHeader::fhe_int160_if_then_else));
 
+  static {
+    FheRegistry.registerFactory(FheInt160.class, FheInt160::new);
+    FheRegistry.registerHandles(FheInt160.class, HANDLES);
+  }
+
   FheInt160() { super(TfheHeader::fhe_int160_destroy); }
 
   @Override protected FheTypeHandles<I256> handles()      { return HANDLES; }
@@ -124,19 +128,24 @@ public final class FheInt160 extends AbstractFheType<I256, FheInt160, Compressed
   @Override protected CompressedFheInt160   newCompressed() { return new CompressedFheInt160(); }
 
   public static FheInt160 encrypt(I256 clearValue, ClientKey clientKey) {
-    return encryptClientKey(HANDLES, clearValue, clientKey, FheInt160::new);
+    return Fhe.encrypt(clearValue, clientKey, FheInt160.class);
   }
   public static FheInt160 encrypt(I256 clearValue, PublicKey publicKey) {
-    return encryptPublicKey(HANDLES, clearValue, publicKey, FheInt160::new);
+    return Fhe.encrypt(clearValue, publicKey, FheInt160.class);
   }
   public static FheInt160 encrypt(I256 clearValue) {
-    return encryptTrivial(HANDLES, clearValue, FheInt160::new);
+    return Fhe.encrypt(clearValue, FheInt160.class);
   }
   public static FheInt160 deserialize(DynamicBuffer buffer, ServerKey serverKey) {
-    return deserialize(HANDLES, buffer, serverKey, FheInt160::new);
+    return Fhe.deserialize(buffer, serverKey, FheInt160.class);
   }
   public static FheInt160 ifThenElse(FheBool condition, FheInt160 thenValue, FheInt160 elseValue) {
-    return ifThenElse(HANDLES, condition, thenValue, elseValue, FheInt160::new);
+    return thenValue.ifThenElse(condition, elseValue);
   }
 
+
+  @Override
+  public FheInt160 abs() {
+    return absImpl();
+  }
 }

--- a/tfhe-java/src/main/java/io/github/rdlopes/tfhe/api/types/extended/FheInt2.java
+++ b/tfhe-java/src/main/java/io/github/rdlopes/tfhe/api/types/extended/FheInt2.java
@@ -3,6 +3,9 @@ package io.github.rdlopes.tfhe.api.types.extended;
 import io.github.rdlopes.tfhe.api.types.*;
 import io.github.rdlopes.tfhe.utils.Generated;
 
+import io.github.rdlopes.tfhe.api.Fhe;
+import io.github.rdlopes.tfhe.api.types.FheBool;
+
 import io.github.rdlopes.tfhe.api.AbstractFheType;
 import io.github.rdlopes.tfhe.api.FheSignedInteger;
 import io.github.rdlopes.tfhe.api.keys.ClientKey;
@@ -17,10 +20,6 @@ import io.github.rdlopes.tfhe.utils.FheRegistry;
 @Generated
 public final class FheInt2 extends AbstractFheType<Byte, FheInt2, CompressedFheInt2>
   implements FheSignedInteger<Byte, FheInt2, CompressedFheInt2> {
-
-  static {
-    FheRegistry.registerFactory(FheInt2.class, FheInt2::new);
-  }
 
   static final FheTypeHandles<Byte> HANDLES = new FheTypeHandles<>(
       FheValueKind.BYTE,
@@ -93,6 +92,11 @@ public final class FheInt2 extends AbstractFheType<Byte, FheInt2, CompressedFheI
           TfheHeader::generate_oblivious_pseudo_random_bounded_fhe_int2,
           TfheHeader::fhe_int2_if_then_else));
 
+  static {
+    FheRegistry.registerFactory(FheInt2.class, FheInt2::new);
+    FheRegistry.registerHandles(FheInt2.class, HANDLES);
+  }
+
   FheInt2() { super(TfheHeader::fhe_int2_destroy); }
 
   @Override protected FheTypeHandles<Byte> handles()      { return HANDLES; }
@@ -100,19 +104,24 @@ public final class FheInt2 extends AbstractFheType<Byte, FheInt2, CompressedFheI
   @Override protected CompressedFheInt2   newCompressed() { return new CompressedFheInt2(); }
 
   public static FheInt2 encrypt(Byte clearValue, ClientKey clientKey) {
-    return encryptClientKey(HANDLES, clearValue, clientKey, FheInt2::new);
+    return Fhe.encrypt(clearValue, clientKey, FheInt2.class);
   }
   public static FheInt2 encrypt(Byte clearValue, PublicKey publicKey) {
-    return encryptPublicKey(HANDLES, clearValue, publicKey, FheInt2::new);
+    return Fhe.encrypt(clearValue, publicKey, FheInt2.class);
   }
   public static FheInt2 encrypt(Byte clearValue) {
-    return encryptTrivial(HANDLES, clearValue, FheInt2::new);
+    return Fhe.encrypt(clearValue, FheInt2.class);
   }
   public static FheInt2 deserialize(DynamicBuffer buffer, ServerKey serverKey) {
-    return deserialize(HANDLES, buffer, serverKey, FheInt2::new);
+    return Fhe.deserialize(buffer, serverKey, FheInt2.class);
   }
   public static FheInt2 ifThenElse(FheBool condition, FheInt2 thenValue, FheInt2 elseValue) {
-    return ifThenElse(HANDLES, condition, thenValue, elseValue, FheInt2::new);
+    return thenValue.ifThenElse(condition, elseValue);
   }
 
+
+  @Override
+  public FheInt2 abs() {
+    return absImpl();
+  }
 }

--- a/tfhe-java/src/main/java/io/github/rdlopes/tfhe/api/types/extended/FheInt2048.java
+++ b/tfhe-java/src/main/java/io/github/rdlopes/tfhe/api/types/extended/FheInt2048.java
@@ -3,6 +3,9 @@ package io.github.rdlopes.tfhe.api.types.extended;
 import io.github.rdlopes.tfhe.api.types.*;
 import io.github.rdlopes.tfhe.utils.Generated;
 
+import io.github.rdlopes.tfhe.api.Fhe;
+import io.github.rdlopes.tfhe.api.types.FheBool;
+
 import io.github.rdlopes.tfhe.api.AbstractFheType;
 import io.github.rdlopes.tfhe.api.FheSignedInteger;
 import io.github.rdlopes.tfhe.api.keys.ClientKey;
@@ -23,10 +26,6 @@ import io.github.rdlopes.tfhe.utils.FheRegistry;
 @Generated
 public final class FheInt2048 extends AbstractFheType<I2048, FheInt2048, CompressedFheInt2048>
   implements FheSignedInteger<I2048, FheInt2048, CompressedFheInt2048> {
-
-  static {
-    FheRegistry.registerFactory(FheInt2048.class, FheInt2048::new);
-  }
 
   static final FheTypeHandles<I2048> HANDLES = new FheTypeHandles<>(
     new FheValueKind.Wide<>(I2048::newEmpty),
@@ -117,6 +116,11 @@ public final class FheInt2048 extends AbstractFheType<I2048, FheInt2048, Compres
           TfheHeader::generate_oblivious_pseudo_random_bounded_fhe_int2048,
           TfheHeader::fhe_int2048_if_then_else));
 
+  static {
+    FheRegistry.registerFactory(FheInt2048.class, FheInt2048::new);
+    FheRegistry.registerHandles(FheInt2048.class, HANDLES);
+  }
+
   FheInt2048() { super(TfheHeader::fhe_int2048_destroy); }
 
   @Override protected FheTypeHandles<I2048> handles()      { return HANDLES; }
@@ -124,19 +128,24 @@ public final class FheInt2048 extends AbstractFheType<I2048, FheInt2048, Compres
   @Override protected CompressedFheInt2048   newCompressed() { return new CompressedFheInt2048(); }
 
   public static FheInt2048 encrypt(I2048 clearValue, ClientKey clientKey) {
-    return encryptClientKey(HANDLES, clearValue, clientKey, FheInt2048::new);
+    return Fhe.encrypt(clearValue, clientKey, FheInt2048.class);
   }
   public static FheInt2048 encrypt(I2048 clearValue, PublicKey publicKey) {
-    return encryptPublicKey(HANDLES, clearValue, publicKey, FheInt2048::new);
+    return Fhe.encrypt(clearValue, publicKey, FheInt2048.class);
   }
   public static FheInt2048 encrypt(I2048 clearValue) {
-    return encryptTrivial(HANDLES, clearValue, FheInt2048::new);
+    return Fhe.encrypt(clearValue, FheInt2048.class);
   }
   public static FheInt2048 deserialize(DynamicBuffer buffer, ServerKey serverKey) {
-    return deserialize(HANDLES, buffer, serverKey, FheInt2048::new);
+    return Fhe.deserialize(buffer, serverKey, FheInt2048.class);
   }
   public static FheInt2048 ifThenElse(FheBool condition, FheInt2048 thenValue, FheInt2048 elseValue) {
-    return ifThenElse(HANDLES, condition, thenValue, elseValue, FheInt2048::new);
+    return thenValue.ifThenElse(condition, elseValue);
   }
 
+
+  @Override
+  public FheInt2048 abs() {
+    return absImpl();
+  }
 }

--- a/tfhe-java/src/main/java/io/github/rdlopes/tfhe/api/types/extended/FheInt256.java
+++ b/tfhe-java/src/main/java/io/github/rdlopes/tfhe/api/types/extended/FheInt256.java
@@ -3,6 +3,9 @@ package io.github.rdlopes.tfhe.api.types.extended;
 import io.github.rdlopes.tfhe.api.types.*;
 import io.github.rdlopes.tfhe.utils.Generated;
 
+import io.github.rdlopes.tfhe.api.Fhe;
+import io.github.rdlopes.tfhe.api.types.FheBool;
+
 import io.github.rdlopes.tfhe.api.AbstractFheType;
 import io.github.rdlopes.tfhe.api.FheSignedInteger;
 import io.github.rdlopes.tfhe.api.keys.ClientKey;
@@ -23,10 +26,6 @@ import io.github.rdlopes.tfhe.utils.FheRegistry;
 @Generated
 public final class FheInt256 extends AbstractFheType<I256, FheInt256, CompressedFheInt256>
   implements FheSignedInteger<I256, FheInt256, CompressedFheInt256> {
-
-  static {
-    FheRegistry.registerFactory(FheInt256.class, FheInt256::new);
-  }
 
   static final FheTypeHandles<I256> HANDLES = new FheTypeHandles<>(
     new FheValueKind.Wide<>(I256::newEmpty),
@@ -117,6 +116,11 @@ public final class FheInt256 extends AbstractFheType<I256, FheInt256, Compressed
           TfheHeader::generate_oblivious_pseudo_random_bounded_fhe_int256,
           TfheHeader::fhe_int256_if_then_else));
 
+  static {
+    FheRegistry.registerFactory(FheInt256.class, FheInt256::new);
+    FheRegistry.registerHandles(FheInt256.class, HANDLES);
+  }
+
   FheInt256() { super(TfheHeader::fhe_int256_destroy); }
 
   @Override protected FheTypeHandles<I256> handles()      { return HANDLES; }
@@ -124,19 +128,24 @@ public final class FheInt256 extends AbstractFheType<I256, FheInt256, Compressed
   @Override protected CompressedFheInt256   newCompressed() { return new CompressedFheInt256(); }
 
   public static FheInt256 encrypt(I256 clearValue, ClientKey clientKey) {
-    return encryptClientKey(HANDLES, clearValue, clientKey, FheInt256::new);
+    return Fhe.encrypt(clearValue, clientKey, FheInt256.class);
   }
   public static FheInt256 encrypt(I256 clearValue, PublicKey publicKey) {
-    return encryptPublicKey(HANDLES, clearValue, publicKey, FheInt256::new);
+    return Fhe.encrypt(clearValue, publicKey, FheInt256.class);
   }
   public static FheInt256 encrypt(I256 clearValue) {
-    return encryptTrivial(HANDLES, clearValue, FheInt256::new);
+    return Fhe.encrypt(clearValue, FheInt256.class);
   }
   public static FheInt256 deserialize(DynamicBuffer buffer, ServerKey serverKey) {
-    return deserialize(HANDLES, buffer, serverKey, FheInt256::new);
+    return Fhe.deserialize(buffer, serverKey, FheInt256.class);
   }
   public static FheInt256 ifThenElse(FheBool condition, FheInt256 thenValue, FheInt256 elseValue) {
-    return ifThenElse(HANDLES, condition, thenValue, elseValue, FheInt256::new);
+    return thenValue.ifThenElse(condition, elseValue);
   }
 
+
+  @Override
+  public FheInt256 abs() {
+    return absImpl();
+  }
 }

--- a/tfhe-java/src/main/java/io/github/rdlopes/tfhe/api/types/extended/FheInt32.java
+++ b/tfhe-java/src/main/java/io/github/rdlopes/tfhe/api/types/extended/FheInt32.java
@@ -3,6 +3,9 @@ package io.github.rdlopes.tfhe.api.types.extended;
 import io.github.rdlopes.tfhe.api.types.*;
 import io.github.rdlopes.tfhe.utils.Generated;
 
+import io.github.rdlopes.tfhe.api.Fhe;
+import io.github.rdlopes.tfhe.api.types.FheBool;
+
 import io.github.rdlopes.tfhe.api.AbstractFheType;
 import io.github.rdlopes.tfhe.api.FheSignedInteger;
 import io.github.rdlopes.tfhe.api.keys.ClientKey;
@@ -17,10 +20,6 @@ import io.github.rdlopes.tfhe.utils.FheRegistry;
 @Generated
 public final class FheInt32 extends AbstractFheType<Integer, FheInt32, CompressedFheInt32>
   implements FheSignedInteger<Integer, FheInt32, CompressedFheInt32> {
-
-  static {
-    FheRegistry.registerFactory(FheInt32.class, FheInt32::new);
-  }
 
   static final FheTypeHandles<Integer> HANDLES = new FheTypeHandles<>(
       FheValueKind.INT,
@@ -93,6 +92,11 @@ public final class FheInt32 extends AbstractFheType<Integer, FheInt32, Compresse
           TfheHeader::generate_oblivious_pseudo_random_bounded_fhe_int32,
           TfheHeader::fhe_int32_if_then_else));
 
+  static {
+    FheRegistry.registerFactory(FheInt32.class, FheInt32::new);
+    FheRegistry.registerHandles(FheInt32.class, HANDLES);
+  }
+
   FheInt32() { super(TfheHeader::fhe_int32_destroy); }
 
   @Override protected FheTypeHandles<Integer> handles()      { return HANDLES; }
@@ -100,19 +104,24 @@ public final class FheInt32 extends AbstractFheType<Integer, FheInt32, Compresse
   @Override protected CompressedFheInt32     newCompressed() { return new CompressedFheInt32(); }
 
   public static FheInt32 encrypt(Integer clearValue, ClientKey clientKey) {
-    return encryptClientKey(HANDLES, clearValue, clientKey, FheInt32::new);
+    return Fhe.encrypt(clearValue, clientKey, FheInt32.class);
   }
   public static FheInt32 encrypt(Integer clearValue, PublicKey publicKey) {
-    return encryptPublicKey(HANDLES, clearValue, publicKey, FheInt32::new);
+    return Fhe.encrypt(clearValue, publicKey, FheInt32.class);
   }
   public static FheInt32 encrypt(Integer clearValue) {
-    return encryptTrivial(HANDLES, clearValue, FheInt32::new);
+    return Fhe.encrypt(clearValue, FheInt32.class);
   }
   public static FheInt32 deserialize(DynamicBuffer buffer, ServerKey serverKey) {
-    return deserialize(HANDLES, buffer, serverKey, FheInt32::new);
+    return Fhe.deserialize(buffer, serverKey, FheInt32.class);
   }
   public static FheInt32 ifThenElse(FheBool condition, FheInt32 thenValue, FheInt32 elseValue) {
-    return ifThenElse(HANDLES, condition, thenValue, elseValue, FheInt32::new);
+    return thenValue.ifThenElse(condition, elseValue);
   }
 
+
+  @Override
+  public FheInt32 abs() {
+    return absImpl();
+  }
 }

--- a/tfhe-java/src/main/java/io/github/rdlopes/tfhe/api/types/extended/FheInt4.java
+++ b/tfhe-java/src/main/java/io/github/rdlopes/tfhe/api/types/extended/FheInt4.java
@@ -3,6 +3,9 @@ package io.github.rdlopes.tfhe.api.types.extended;
 import io.github.rdlopes.tfhe.api.types.*;
 import io.github.rdlopes.tfhe.utils.Generated;
 
+import io.github.rdlopes.tfhe.api.Fhe;
+import io.github.rdlopes.tfhe.api.types.FheBool;
+
 import io.github.rdlopes.tfhe.api.AbstractFheType;
 import io.github.rdlopes.tfhe.api.FheSignedInteger;
 import io.github.rdlopes.tfhe.api.keys.ClientKey;
@@ -17,10 +20,6 @@ import io.github.rdlopes.tfhe.utils.FheRegistry;
 @Generated
 public final class FheInt4 extends AbstractFheType<Byte, FheInt4, CompressedFheInt4>
   implements FheSignedInteger<Byte, FheInt4, CompressedFheInt4> {
-
-  static {
-    FheRegistry.registerFactory(FheInt4.class, FheInt4::new);
-  }
 
   static final FheTypeHandles<Byte> HANDLES = new FheTypeHandles<>(
       FheValueKind.BYTE,
@@ -93,6 +92,11 @@ public final class FheInt4 extends AbstractFheType<Byte, FheInt4, CompressedFheI
           TfheHeader::generate_oblivious_pseudo_random_bounded_fhe_int4,
           TfheHeader::fhe_int4_if_then_else));
 
+  static {
+    FheRegistry.registerFactory(FheInt4.class, FheInt4::new);
+    FheRegistry.registerHandles(FheInt4.class, HANDLES);
+  }
+
   FheInt4() { super(TfheHeader::fhe_int4_destroy); }
 
   @Override protected FheTypeHandles<Byte> handles()      { return HANDLES; }
@@ -100,19 +104,24 @@ public final class FheInt4 extends AbstractFheType<Byte, FheInt4, CompressedFheI
   @Override protected CompressedFheInt4   newCompressed() { return new CompressedFheInt4(); }
 
   public static FheInt4 encrypt(Byte clearValue, ClientKey clientKey) {
-    return encryptClientKey(HANDLES, clearValue, clientKey, FheInt4::new);
+    return Fhe.encrypt(clearValue, clientKey, FheInt4.class);
   }
   public static FheInt4 encrypt(Byte clearValue, PublicKey publicKey) {
-    return encryptPublicKey(HANDLES, clearValue, publicKey, FheInt4::new);
+    return Fhe.encrypt(clearValue, publicKey, FheInt4.class);
   }
   public static FheInt4 encrypt(Byte clearValue) {
-    return encryptTrivial(HANDLES, clearValue, FheInt4::new);
+    return Fhe.encrypt(clearValue, FheInt4.class);
   }
   public static FheInt4 deserialize(DynamicBuffer buffer, ServerKey serverKey) {
-    return deserialize(HANDLES, buffer, serverKey, FheInt4::new);
+    return Fhe.deserialize(buffer, serverKey, FheInt4.class);
   }
   public static FheInt4 ifThenElse(FheBool condition, FheInt4 thenValue, FheInt4 elseValue) {
-    return ifThenElse(HANDLES, condition, thenValue, elseValue, FheInt4::new);
+    return thenValue.ifThenElse(condition, elseValue);
   }
 
+
+  @Override
+  public FheInt4 abs() {
+    return absImpl();
+  }
 }

--- a/tfhe-java/src/main/java/io/github/rdlopes/tfhe/api/types/extended/FheInt512.java
+++ b/tfhe-java/src/main/java/io/github/rdlopes/tfhe/api/types/extended/FheInt512.java
@@ -3,6 +3,9 @@ package io.github.rdlopes.tfhe.api.types.extended;
 import io.github.rdlopes.tfhe.api.types.*;
 import io.github.rdlopes.tfhe.utils.Generated;
 
+import io.github.rdlopes.tfhe.api.Fhe;
+import io.github.rdlopes.tfhe.api.types.FheBool;
+
 import io.github.rdlopes.tfhe.api.AbstractFheType;
 import io.github.rdlopes.tfhe.api.FheSignedInteger;
 import io.github.rdlopes.tfhe.api.keys.ClientKey;
@@ -23,10 +26,6 @@ import io.github.rdlopes.tfhe.utils.FheRegistry;
 @Generated
 public final class FheInt512 extends AbstractFheType<I512, FheInt512, CompressedFheInt512>
   implements FheSignedInteger<I512, FheInt512, CompressedFheInt512> {
-
-  static {
-    FheRegistry.registerFactory(FheInt512.class, FheInt512::new);
-  }
 
   static final FheTypeHandles<I512> HANDLES = new FheTypeHandles<>(
     new FheValueKind.Wide<>(I512::newEmpty),
@@ -117,6 +116,11 @@ public final class FheInt512 extends AbstractFheType<I512, FheInt512, Compressed
           TfheHeader::generate_oblivious_pseudo_random_bounded_fhe_int512,
           TfheHeader::fhe_int512_if_then_else));
 
+  static {
+    FheRegistry.registerFactory(FheInt512.class, FheInt512::new);
+    FheRegistry.registerHandles(FheInt512.class, HANDLES);
+  }
+
   FheInt512() { super(TfheHeader::fhe_int512_destroy); }
 
   @Override protected FheTypeHandles<I512> handles()      { return HANDLES; }
@@ -124,19 +128,24 @@ public final class FheInt512 extends AbstractFheType<I512, FheInt512, Compressed
   @Override protected CompressedFheInt512   newCompressed() { return new CompressedFheInt512(); }
 
   public static FheInt512 encrypt(I512 clearValue, ClientKey clientKey) {
-    return encryptClientKey(HANDLES, clearValue, clientKey, FheInt512::new);
+    return Fhe.encrypt(clearValue, clientKey, FheInt512.class);
   }
   public static FheInt512 encrypt(I512 clearValue, PublicKey publicKey) {
-    return encryptPublicKey(HANDLES, clearValue, publicKey, FheInt512::new);
+    return Fhe.encrypt(clearValue, publicKey, FheInt512.class);
   }
   public static FheInt512 encrypt(I512 clearValue) {
-    return encryptTrivial(HANDLES, clearValue, FheInt512::new);
+    return Fhe.encrypt(clearValue, FheInt512.class);
   }
   public static FheInt512 deserialize(DynamicBuffer buffer, ServerKey serverKey) {
-    return deserialize(HANDLES, buffer, serverKey, FheInt512::new);
+    return Fhe.deserialize(buffer, serverKey, FheInt512.class);
   }
   public static FheInt512 ifThenElse(FheBool condition, FheInt512 thenValue, FheInt512 elseValue) {
-    return ifThenElse(HANDLES, condition, thenValue, elseValue, FheInt512::new);
+    return thenValue.ifThenElse(condition, elseValue);
   }
 
+
+  @Override
+  public FheInt512 abs() {
+    return absImpl();
+  }
 }

--- a/tfhe-java/src/main/java/io/github/rdlopes/tfhe/api/types/extended/FheInt6.java
+++ b/tfhe-java/src/main/java/io/github/rdlopes/tfhe/api/types/extended/FheInt6.java
@@ -3,6 +3,9 @@ package io.github.rdlopes.tfhe.api.types.extended;
 import io.github.rdlopes.tfhe.api.types.*;
 import io.github.rdlopes.tfhe.utils.Generated;
 
+import io.github.rdlopes.tfhe.api.Fhe;
+import io.github.rdlopes.tfhe.api.types.FheBool;
+
 import io.github.rdlopes.tfhe.api.AbstractFheType;
 import io.github.rdlopes.tfhe.api.FheSignedInteger;
 import io.github.rdlopes.tfhe.api.keys.ClientKey;
@@ -17,10 +20,6 @@ import io.github.rdlopes.tfhe.utils.FheRegistry;
 @Generated
 public final class FheInt6 extends AbstractFheType<Byte, FheInt6, CompressedFheInt6>
   implements FheSignedInteger<Byte, FheInt6, CompressedFheInt6> {
-
-  static {
-    FheRegistry.registerFactory(FheInt6.class, FheInt6::new);
-  }
 
   static final FheTypeHandles<Byte> HANDLES = new FheTypeHandles<>(
       FheValueKind.BYTE,
@@ -93,6 +92,11 @@ public final class FheInt6 extends AbstractFheType<Byte, FheInt6, CompressedFheI
           TfheHeader::generate_oblivious_pseudo_random_bounded_fhe_int6,
           TfheHeader::fhe_int6_if_then_else));
 
+  static {
+    FheRegistry.registerFactory(FheInt6.class, FheInt6::new);
+    FheRegistry.registerHandles(FheInt6.class, HANDLES);
+  }
+
   FheInt6() { super(TfheHeader::fhe_int6_destroy); }
 
   @Override protected FheTypeHandles<Byte> handles()      { return HANDLES; }
@@ -100,19 +104,24 @@ public final class FheInt6 extends AbstractFheType<Byte, FheInt6, CompressedFheI
   @Override protected CompressedFheInt6   newCompressed() { return new CompressedFheInt6(); }
 
   public static FheInt6 encrypt(Byte clearValue, ClientKey clientKey) {
-    return encryptClientKey(HANDLES, clearValue, clientKey, FheInt6::new);
+    return Fhe.encrypt(clearValue, clientKey, FheInt6.class);
   }
   public static FheInt6 encrypt(Byte clearValue, PublicKey publicKey) {
-    return encryptPublicKey(HANDLES, clearValue, publicKey, FheInt6::new);
+    return Fhe.encrypt(clearValue, publicKey, FheInt6.class);
   }
   public static FheInt6 encrypt(Byte clearValue) {
-    return encryptTrivial(HANDLES, clearValue, FheInt6::new);
+    return Fhe.encrypt(clearValue, FheInt6.class);
   }
   public static FheInt6 deserialize(DynamicBuffer buffer, ServerKey serverKey) {
-    return deserialize(HANDLES, buffer, serverKey, FheInt6::new);
+    return Fhe.deserialize(buffer, serverKey, FheInt6.class);
   }
   public static FheInt6 ifThenElse(FheBool condition, FheInt6 thenValue, FheInt6 elseValue) {
-    return ifThenElse(HANDLES, condition, thenValue, elseValue, FheInt6::new);
+    return thenValue.ifThenElse(condition, elseValue);
   }
 
+
+  @Override
+  public FheInt6 abs() {
+    return absImpl();
+  }
 }

--- a/tfhe-java/src/main/java/io/github/rdlopes/tfhe/api/types/extended/FheInt64.java
+++ b/tfhe-java/src/main/java/io/github/rdlopes/tfhe/api/types/extended/FheInt64.java
@@ -3,6 +3,9 @@ package io.github.rdlopes.tfhe.api.types.extended;
 import io.github.rdlopes.tfhe.api.types.*;
 import io.github.rdlopes.tfhe.utils.Generated;
 
+import io.github.rdlopes.tfhe.api.Fhe;
+import io.github.rdlopes.tfhe.api.types.FheBool;
+
 import io.github.rdlopes.tfhe.api.AbstractFheType;
 import io.github.rdlopes.tfhe.api.FheSignedInteger;
 import io.github.rdlopes.tfhe.api.keys.ClientKey;
@@ -17,10 +20,6 @@ import io.github.rdlopes.tfhe.utils.FheRegistry;
 @Generated
 public final class FheInt64 extends AbstractFheType<Long, FheInt64, CompressedFheInt64>
   implements FheSignedInteger<Long, FheInt64, CompressedFheInt64> {
-
-  static {
-    FheRegistry.registerFactory(FheInt64.class, FheInt64::new);
-  }
 
   static final FheTypeHandles<Long> HANDLES = new FheTypeHandles<>(
       FheValueKind.LONG,
@@ -93,6 +92,11 @@ public final class FheInt64 extends AbstractFheType<Long, FheInt64, CompressedFh
           TfheHeader::generate_oblivious_pseudo_random_bounded_fhe_int64,
           TfheHeader::fhe_int64_if_then_else));
 
+  static {
+    FheRegistry.registerFactory(FheInt64.class, FheInt64::new);
+    FheRegistry.registerHandles(FheInt64.class, HANDLES);
+  }
+
   FheInt64() { super(TfheHeader::fhe_int64_destroy); }
 
   @Override protected FheTypeHandles<Long> handles()      { return HANDLES; }
@@ -100,19 +104,24 @@ public final class FheInt64 extends AbstractFheType<Long, FheInt64, CompressedFh
   @Override protected CompressedFheInt64  newCompressed() { return new CompressedFheInt64(); }
 
   public static FheInt64 encrypt(Long clearValue, ClientKey clientKey) {
-    return encryptClientKey(HANDLES, clearValue, clientKey, FheInt64::new);
+    return Fhe.encrypt(clearValue, clientKey, FheInt64.class);
   }
   public static FheInt64 encrypt(Long clearValue, PublicKey publicKey) {
-    return encryptPublicKey(HANDLES, clearValue, publicKey, FheInt64::new);
+    return Fhe.encrypt(clearValue, publicKey, FheInt64.class);
   }
   public static FheInt64 encrypt(Long clearValue) {
-    return encryptTrivial(HANDLES, clearValue, FheInt64::new);
+    return Fhe.encrypt(clearValue, FheInt64.class);
   }
   public static FheInt64 deserialize(DynamicBuffer buffer, ServerKey serverKey) {
-    return deserialize(HANDLES, buffer, serverKey, FheInt64::new);
+    return Fhe.deserialize(buffer, serverKey, FheInt64.class);
   }
   public static FheInt64 ifThenElse(FheBool condition, FheInt64 thenValue, FheInt64 elseValue) {
-    return ifThenElse(HANDLES, condition, thenValue, elseValue, FheInt64::new);
+    return thenValue.ifThenElse(condition, elseValue);
   }
 
+
+  @Override
+  public FheInt64 abs() {
+    return absImpl();
+  }
 }

--- a/tfhe-java/src/main/java/io/github/rdlopes/tfhe/api/types/extended/FheUint10.java
+++ b/tfhe-java/src/main/java/io/github/rdlopes/tfhe/api/types/extended/FheUint10.java
@@ -3,6 +3,9 @@ package io.github.rdlopes.tfhe.api.types.extended;
 import io.github.rdlopes.tfhe.api.types.*;
 import io.github.rdlopes.tfhe.utils.Generated;
 
+import io.github.rdlopes.tfhe.api.Fhe;
+import io.github.rdlopes.tfhe.api.types.FheBool;
+
 import io.github.rdlopes.tfhe.utils.FheRegistry;
 
 import io.github.rdlopes.tfhe.api.*;
@@ -17,10 +20,6 @@ import io.github.rdlopes.tfhe.ffm.TfheHeader;
 @Generated
 public final class FheUint10 extends AbstractFheUnsignedInteger<Short, FheUint10, CompressedFheUint10>
     implements FheUnsignedInteger<Short, FheUint10, CompressedFheUint10> {
-
-  static {
-    FheRegistry.registerFactory(FheUint10.class, FheUint10::new);
-  }
 
   static final FheTypeHandles<Short> HANDLES = new FheTypeHandles<>(
       FheValueKind.SHORT,
@@ -93,6 +92,11 @@ public final class FheUint10 extends AbstractFheUnsignedInteger<Short, FheUint10
           TfheHeader::generate_oblivious_pseudo_random_bounded_fhe_uint10,
           TfheHeader::fhe_uint10_if_then_else));
 
+  static {
+    FheRegistry.registerFactory(FheUint10.class, FheUint10::new);
+    FheRegistry.registerHandles(FheUint10.class, HANDLES);
+  }
+
   FheUint10() { super(TfheHeader::fhe_uint10_destroy); }
 
   @Override protected FheTypeHandles<Short> handles()      { return HANDLES; }
@@ -100,19 +104,19 @@ public final class FheUint10 extends AbstractFheUnsignedInteger<Short, FheUint10
   @Override protected CompressedFheUint10  newCompressed() { return new CompressedFheUint10(); }
 
   public static FheUint10 encrypt(Short clearValue, ClientKey clientKey) {
-    return encryptClientKey(HANDLES, clearValue, clientKey, FheUint10::new);
+    return Fhe.encrypt(clearValue, clientKey, FheUint10.class);
   }
   public static FheUint10 encrypt(Short clearValue, PublicKey publicKey) {
-    return encryptPublicKey(HANDLES, clearValue, publicKey, FheUint10::new);
+    return Fhe.encrypt(clearValue, publicKey, FheUint10.class);
   }
   public static FheUint10 encrypt(Short clearValue) {
-    return encryptTrivial(HANDLES, clearValue, FheUint10::new);
+    return Fhe.encrypt(clearValue, FheUint10.class);
   }
   public static FheUint10 deserialize(DynamicBuffer buffer, ServerKey serverKey) {
-    return deserialize(HANDLES, buffer, serverKey, FheUint10::new);
+    return Fhe.deserialize(buffer, serverKey, FheUint10.class);
   }
   public static FheUint10 ifThenElse(FheBool condition, FheUint10 thenValue, FheUint10 elseValue) {
-    return ifThenElse(HANDLES, condition, thenValue, elseValue, FheUint10::new);
+    return thenValue.ifThenElse(condition, elseValue);
   }
 
 }

--- a/tfhe-java/src/main/java/io/github/rdlopes/tfhe/api/types/extended/FheUint1024.java
+++ b/tfhe-java/src/main/java/io/github/rdlopes/tfhe/api/types/extended/FheUint1024.java
@@ -3,6 +3,9 @@ package io.github.rdlopes.tfhe.api.types.extended;
 import io.github.rdlopes.tfhe.api.types.*;
 import io.github.rdlopes.tfhe.utils.Generated;
 
+import io.github.rdlopes.tfhe.api.Fhe;
+import io.github.rdlopes.tfhe.api.types.FheBool;
+
 import io.github.rdlopes.tfhe.api.AbstractFheType;
 import io.github.rdlopes.tfhe.api.AbstractFheUnsignedInteger;
 import io.github.rdlopes.tfhe.api.FheUnsignedInteger;
@@ -24,10 +27,6 @@ import io.github.rdlopes.tfhe.utils.FheRegistry;
 @Generated
 public final class FheUint1024 extends AbstractFheUnsignedInteger<U1024, FheUint1024, CompressedFheUint1024>
     implements FheUnsignedInteger<U1024, FheUint1024, CompressedFheUint1024> {
-
-  static {
-    FheRegistry.registerFactory(FheUint1024.class, FheUint1024::new);
-  }
 
   static final FheTypeHandles<U1024> HANDLES = new FheTypeHandles<>(
     new FheValueKind.Wide<>(U1024::newEmpty),
@@ -118,6 +117,11 @@ public final class FheUint1024 extends AbstractFheUnsignedInteger<U1024, FheUint
           TfheHeader::generate_oblivious_pseudo_random_bounded_fhe_uint1024,
           TfheHeader::fhe_uint1024_if_then_else));
 
+  static {
+    FheRegistry.registerFactory(FheUint1024.class, FheUint1024::new);
+    FheRegistry.registerHandles(FheUint1024.class, HANDLES);
+  }
+
   FheUint1024() { super(TfheHeader::fhe_uint1024_destroy); }
 
   @Override protected FheTypeHandles<U1024> handles()      { return HANDLES; }
@@ -125,19 +129,19 @@ public final class FheUint1024 extends AbstractFheUnsignedInteger<U1024, FheUint
   @Override protected CompressedFheUint1024   newCompressed() { return new CompressedFheUint1024(); }
 
   public static FheUint1024 encrypt(U1024 clearValue, ClientKey clientKey) {
-    return encryptClientKey(HANDLES, clearValue, clientKey, FheUint1024::new);
+    return Fhe.encrypt(clearValue, clientKey, FheUint1024.class);
   }
   public static FheUint1024 encrypt(U1024 clearValue, PublicKey publicKey) {
-    return encryptPublicKey(HANDLES, clearValue, publicKey, FheUint1024::new);
+    return Fhe.encrypt(clearValue, publicKey, FheUint1024.class);
   }
   public static FheUint1024 encrypt(U1024 clearValue) {
-    return encryptTrivial(HANDLES, clearValue, FheUint1024::new);
+    return Fhe.encrypt(clearValue, FheUint1024.class);
   }
   public static FheUint1024 deserialize(DynamicBuffer buffer, ServerKey serverKey) {
-    return deserialize(HANDLES, buffer, serverKey, FheUint1024::new);
+    return Fhe.deserialize(buffer, serverKey, FheUint1024.class);
   }
   public static FheUint1024 ifThenElse(FheBool condition, FheUint1024 thenValue, FheUint1024 elseValue) {
-    return ifThenElse(HANDLES, condition, thenValue, elseValue, FheUint1024::new);
+    return thenValue.ifThenElse(condition, elseValue);
   }
 
 }

--- a/tfhe-java/src/main/java/io/github/rdlopes/tfhe/api/types/extended/FheUint12.java
+++ b/tfhe-java/src/main/java/io/github/rdlopes/tfhe/api/types/extended/FheUint12.java
@@ -3,6 +3,9 @@ package io.github.rdlopes.tfhe.api.types.extended;
 import io.github.rdlopes.tfhe.api.types.*;
 import io.github.rdlopes.tfhe.utils.Generated;
 
+import io.github.rdlopes.tfhe.api.Fhe;
+import io.github.rdlopes.tfhe.api.types.FheBool;
+
 import io.github.rdlopes.tfhe.utils.FheRegistry;
 
 import io.github.rdlopes.tfhe.api.*;
@@ -17,10 +20,6 @@ import io.github.rdlopes.tfhe.ffm.TfheHeader;
 @Generated
 public final class FheUint12 extends AbstractFheUnsignedInteger<Short, FheUint12, CompressedFheUint12>
     implements FheUnsignedInteger<Short, FheUint12, CompressedFheUint12> {
-
-  static {
-    FheRegistry.registerFactory(FheUint12.class, FheUint12::new);
-  }
 
   static final FheTypeHandles<Short> HANDLES = new FheTypeHandles<>(
       FheValueKind.SHORT,
@@ -93,6 +92,11 @@ public final class FheUint12 extends AbstractFheUnsignedInteger<Short, FheUint12
           TfheHeader::generate_oblivious_pseudo_random_bounded_fhe_uint12,
           TfheHeader::fhe_uint12_if_then_else));
 
+  static {
+    FheRegistry.registerFactory(FheUint12.class, FheUint12::new);
+    FheRegistry.registerHandles(FheUint12.class, HANDLES);
+  }
+
   FheUint12() { super(TfheHeader::fhe_uint12_destroy); }
 
   @Override protected FheTypeHandles<Short> handles()      { return HANDLES; }
@@ -100,19 +104,19 @@ public final class FheUint12 extends AbstractFheUnsignedInteger<Short, FheUint12
   @Override protected CompressedFheUint12  newCompressed() { return new CompressedFheUint12(); }
 
   public static FheUint12 encrypt(Short clearValue, ClientKey clientKey) {
-    return encryptClientKey(HANDLES, clearValue, clientKey, FheUint12::new);
+    return Fhe.encrypt(clearValue, clientKey, FheUint12.class);
   }
   public static FheUint12 encrypt(Short clearValue, PublicKey publicKey) {
-    return encryptPublicKey(HANDLES, clearValue, publicKey, FheUint12::new);
+    return Fhe.encrypt(clearValue, publicKey, FheUint12.class);
   }
   public static FheUint12 encrypt(Short clearValue) {
-    return encryptTrivial(HANDLES, clearValue, FheUint12::new);
+    return Fhe.encrypt(clearValue, FheUint12.class);
   }
   public static FheUint12 deserialize(DynamicBuffer buffer, ServerKey serverKey) {
-    return deserialize(HANDLES, buffer, serverKey, FheUint12::new);
+    return Fhe.deserialize(buffer, serverKey, FheUint12.class);
   }
   public static FheUint12 ifThenElse(FheBool condition, FheUint12 thenValue, FheUint12 elseValue) {
-    return ifThenElse(HANDLES, condition, thenValue, elseValue, FheUint12::new);
+    return thenValue.ifThenElse(condition, elseValue);
   }
 
 }

--- a/tfhe-java/src/main/java/io/github/rdlopes/tfhe/api/types/extended/FheUint14.java
+++ b/tfhe-java/src/main/java/io/github/rdlopes/tfhe/api/types/extended/FheUint14.java
@@ -3,6 +3,9 @@ package io.github.rdlopes.tfhe.api.types.extended;
 import io.github.rdlopes.tfhe.api.types.*;
 import io.github.rdlopes.tfhe.utils.Generated;
 
+import io.github.rdlopes.tfhe.api.Fhe;
+import io.github.rdlopes.tfhe.api.types.FheBool;
+
 import io.github.rdlopes.tfhe.utils.FheRegistry;
 
 import io.github.rdlopes.tfhe.api.*;
@@ -17,10 +20,6 @@ import io.github.rdlopes.tfhe.ffm.TfheHeader;
 @Generated
 public final class FheUint14 extends AbstractFheUnsignedInteger<Short, FheUint14, CompressedFheUint14>
     implements FheUnsignedInteger<Short, FheUint14, CompressedFheUint14> {
-
-  static {
-    FheRegistry.registerFactory(FheUint14.class, FheUint14::new);
-  }
 
   static final FheTypeHandles<Short> HANDLES = new FheTypeHandles<>(
       FheValueKind.SHORT,
@@ -93,6 +92,11 @@ public final class FheUint14 extends AbstractFheUnsignedInteger<Short, FheUint14
           TfheHeader::generate_oblivious_pseudo_random_bounded_fhe_uint14,
           TfheHeader::fhe_uint14_if_then_else));
 
+  static {
+    FheRegistry.registerFactory(FheUint14.class, FheUint14::new);
+    FheRegistry.registerHandles(FheUint14.class, HANDLES);
+  }
+
   FheUint14() { super(TfheHeader::fhe_uint14_destroy); }
 
   @Override protected FheTypeHandles<Short> handles()      { return HANDLES; }
@@ -100,19 +104,19 @@ public final class FheUint14 extends AbstractFheUnsignedInteger<Short, FheUint14
   @Override protected CompressedFheUint14  newCompressed() { return new CompressedFheUint14(); }
 
   public static FheUint14 encrypt(Short clearValue, ClientKey clientKey) {
-    return encryptClientKey(HANDLES, clearValue, clientKey, FheUint14::new);
+    return Fhe.encrypt(clearValue, clientKey, FheUint14.class);
   }
   public static FheUint14 encrypt(Short clearValue, PublicKey publicKey) {
-    return encryptPublicKey(HANDLES, clearValue, publicKey, FheUint14::new);
+    return Fhe.encrypt(clearValue, publicKey, FheUint14.class);
   }
   public static FheUint14 encrypt(Short clearValue) {
-    return encryptTrivial(HANDLES, clearValue, FheUint14::new);
+    return Fhe.encrypt(clearValue, FheUint14.class);
   }
   public static FheUint14 deserialize(DynamicBuffer buffer, ServerKey serverKey) {
-    return deserialize(HANDLES, buffer, serverKey, FheUint14::new);
+    return Fhe.deserialize(buffer, serverKey, FheUint14.class);
   }
   public static FheUint14 ifThenElse(FheBool condition, FheUint14 thenValue, FheUint14 elseValue) {
-    return ifThenElse(HANDLES, condition, thenValue, elseValue, FheUint14::new);
+    return thenValue.ifThenElse(condition, elseValue);
   }
 
 }

--- a/tfhe-java/src/main/java/io/github/rdlopes/tfhe/api/types/extended/FheUint16.java
+++ b/tfhe-java/src/main/java/io/github/rdlopes/tfhe/api/types/extended/FheUint16.java
@@ -3,6 +3,9 @@ package io.github.rdlopes.tfhe.api.types.extended;
 import io.github.rdlopes.tfhe.api.types.*;
 import io.github.rdlopes.tfhe.utils.Generated;
 
+import io.github.rdlopes.tfhe.api.Fhe;
+import io.github.rdlopes.tfhe.api.types.FheBool;
+
 import io.github.rdlopes.tfhe.utils.FheRegistry;
 
 import io.github.rdlopes.tfhe.api.*;
@@ -17,10 +20,6 @@ import io.github.rdlopes.tfhe.ffm.TfheHeader;
 @Generated
 public final class FheUint16 extends AbstractFheUnsignedInteger<Short, FheUint16, CompressedFheUint16>
     implements FheUnsignedInteger<Short, FheUint16, CompressedFheUint16> {
-
-  static {
-    FheRegistry.registerFactory(FheUint16.class, FheUint16::new);
-  }
 
   static final FheTypeHandles<Short> HANDLES = new FheTypeHandles<>(
       FheValueKind.SHORT,
@@ -93,6 +92,11 @@ public final class FheUint16 extends AbstractFheUnsignedInteger<Short, FheUint16
           TfheHeader::generate_oblivious_pseudo_random_bounded_fhe_uint16,
           TfheHeader::fhe_uint16_if_then_else));
 
+  static {
+    FheRegistry.registerFactory(FheUint16.class, FheUint16::new);
+    FheRegistry.registerHandles(FheUint16.class, HANDLES);
+  }
+
   FheUint16() { super(TfheHeader::fhe_uint16_destroy); }
 
   @Override protected FheTypeHandles<Short> handles()      { return HANDLES; }
@@ -100,19 +104,19 @@ public final class FheUint16 extends AbstractFheUnsignedInteger<Short, FheUint16
   @Override protected CompressedFheUint16  newCompressed() { return new CompressedFheUint16(); }
 
   public static FheUint16 encrypt(Short clearValue, ClientKey clientKey) {
-    return encryptClientKey(HANDLES, clearValue, clientKey, FheUint16::new);
+    return Fhe.encrypt(clearValue, clientKey, FheUint16.class);
   }
   public static FheUint16 encrypt(Short clearValue, PublicKey publicKey) {
-    return encryptPublicKey(HANDLES, clearValue, publicKey, FheUint16::new);
+    return Fhe.encrypt(clearValue, publicKey, FheUint16.class);
   }
   public static FheUint16 encrypt(Short clearValue) {
-    return encryptTrivial(HANDLES, clearValue, FheUint16::new);
+    return Fhe.encrypt(clearValue, FheUint16.class);
   }
   public static FheUint16 deserialize(DynamicBuffer buffer, ServerKey serverKey) {
-    return deserialize(HANDLES, buffer, serverKey, FheUint16::new);
+    return Fhe.deserialize(buffer, serverKey, FheUint16.class);
   }
   public static FheUint16 ifThenElse(FheBool condition, FheUint16 thenValue, FheUint16 elseValue) {
-    return ifThenElse(HANDLES, condition, thenValue, elseValue, FheUint16::new);
+    return thenValue.ifThenElse(condition, elseValue);
   }
 
 }

--- a/tfhe-java/src/main/java/io/github/rdlopes/tfhe/api/types/extended/FheUint160.java
+++ b/tfhe-java/src/main/java/io/github/rdlopes/tfhe/api/types/extended/FheUint160.java
@@ -3,6 +3,9 @@ package io.github.rdlopes.tfhe.api.types.extended;
 import io.github.rdlopes.tfhe.api.types.*;
 import io.github.rdlopes.tfhe.utils.Generated;
 
+import io.github.rdlopes.tfhe.api.Fhe;
+import io.github.rdlopes.tfhe.api.types.FheBool;
+
 import io.github.rdlopes.tfhe.api.AbstractFheType;
 import io.github.rdlopes.tfhe.api.AbstractFheUnsignedInteger;
 import io.github.rdlopes.tfhe.api.FheUnsignedInteger;
@@ -24,10 +27,6 @@ import io.github.rdlopes.tfhe.utils.FheRegistry;
 @Generated
 public final class FheUint160 extends AbstractFheUnsignedInteger<U256, FheUint160, CompressedFheUint160>
     implements FheUnsignedInteger<U256, FheUint160, CompressedFheUint160> {
-
-  static {
-    FheRegistry.registerFactory(FheUint160.class, FheUint160::new);
-  }
 
   static final FheTypeHandles<U256> HANDLES = new FheTypeHandles<>(
     new FheValueKind.Wide<>(U256::newEmpty),
@@ -118,6 +117,11 @@ public final class FheUint160 extends AbstractFheUnsignedInteger<U256, FheUint16
           TfheHeader::generate_oblivious_pseudo_random_bounded_fhe_uint160,
           TfheHeader::fhe_uint160_if_then_else));
 
+  static {
+    FheRegistry.registerFactory(FheUint160.class, FheUint160::new);
+    FheRegistry.registerHandles(FheUint160.class, HANDLES);
+  }
+
   FheUint160() { super(TfheHeader::fhe_uint160_destroy); }
 
   @Override protected FheTypeHandles<U256> handles()      { return HANDLES; }
@@ -125,19 +129,19 @@ public final class FheUint160 extends AbstractFheUnsignedInteger<U256, FheUint16
   @Override protected CompressedFheUint160   newCompressed() { return new CompressedFheUint160(); }
 
   public static FheUint160 encrypt(U256 clearValue, ClientKey clientKey) {
-    return encryptClientKey(HANDLES, clearValue, clientKey, FheUint160::new);
+    return Fhe.encrypt(clearValue, clientKey, FheUint160.class);
   }
   public static FheUint160 encrypt(U256 clearValue, PublicKey publicKey) {
-    return encryptPublicKey(HANDLES, clearValue, publicKey, FheUint160::new);
+    return Fhe.encrypt(clearValue, publicKey, FheUint160.class);
   }
   public static FheUint160 encrypt(U256 clearValue) {
-    return encryptTrivial(HANDLES, clearValue, FheUint160::new);
+    return Fhe.encrypt(clearValue, FheUint160.class);
   }
   public static FheUint160 deserialize(DynamicBuffer buffer, ServerKey serverKey) {
-    return deserialize(HANDLES, buffer, serverKey, FheUint160::new);
+    return Fhe.deserialize(buffer, serverKey, FheUint160.class);
   }
   public static FheUint160 ifThenElse(FheBool condition, FheUint160 thenValue, FheUint160 elseValue) {
-    return ifThenElse(HANDLES, condition, thenValue, elseValue, FheUint160::new);
+    return thenValue.ifThenElse(condition, elseValue);
   }
 
 }

--- a/tfhe-java/src/main/java/io/github/rdlopes/tfhe/api/types/extended/FheUint2.java
+++ b/tfhe-java/src/main/java/io/github/rdlopes/tfhe/api/types/extended/FheUint2.java
@@ -3,6 +3,9 @@ package io.github.rdlopes.tfhe.api.types.extended;
 import io.github.rdlopes.tfhe.api.types.*;
 import io.github.rdlopes.tfhe.utils.Generated;
 
+import io.github.rdlopes.tfhe.api.Fhe;
+import io.github.rdlopes.tfhe.api.types.FheBool;
+
 import io.github.rdlopes.tfhe.utils.FheRegistry;
 
 import io.github.rdlopes.tfhe.api.*;
@@ -17,10 +20,6 @@ import io.github.rdlopes.tfhe.ffm.TfheHeader;
 @Generated
 public final class FheUint2 extends AbstractFheUnsignedInteger<Byte, FheUint2, CompressedFheUint2>
     implements FheUnsignedInteger<Byte, FheUint2, CompressedFheUint2> {
-
-  static {
-    FheRegistry.registerFactory(FheUint2.class, FheUint2::new);
-  }
 
   static final FheTypeHandles<Byte> HANDLES = new FheTypeHandles<>(
       FheValueKind.BYTE,
@@ -93,6 +92,11 @@ public final class FheUint2 extends AbstractFheUnsignedInteger<Byte, FheUint2, C
           TfheHeader::generate_oblivious_pseudo_random_bounded_fhe_uint2,
           TfheHeader::fhe_uint2_if_then_else));
 
+  static {
+    FheRegistry.registerFactory(FheUint2.class, FheUint2::new);
+    FheRegistry.registerHandles(FheUint2.class, HANDLES);
+  }
+
   FheUint2() { super(TfheHeader::fhe_uint2_destroy); }
 
   @Override protected FheTypeHandles<Byte>  handles()      { return HANDLES; }
@@ -100,19 +104,19 @@ public final class FheUint2 extends AbstractFheUnsignedInteger<Byte, FheUint2, C
   @Override protected CompressedFheUint2   newCompressed() { return new CompressedFheUint2(); }
 
   public static FheUint2 encrypt(Byte clearValue, ClientKey clientKey) {
-    return encryptClientKey(HANDLES, clearValue, clientKey, FheUint2::new);
+    return Fhe.encrypt(clearValue, clientKey, FheUint2.class);
   }
   public static FheUint2 encrypt(Byte clearValue, PublicKey publicKey) {
-    return encryptPublicKey(HANDLES, clearValue, publicKey, FheUint2::new);
+    return Fhe.encrypt(clearValue, publicKey, FheUint2.class);
   }
   public static FheUint2 encrypt(Byte clearValue) {
-    return encryptTrivial(HANDLES, clearValue, FheUint2::new);
+    return Fhe.encrypt(clearValue, FheUint2.class);
   }
   public static FheUint2 deserialize(DynamicBuffer buffer, ServerKey serverKey) {
-    return deserialize(HANDLES, buffer, serverKey, FheUint2::new);
+    return Fhe.deserialize(buffer, serverKey, FheUint2.class);
   }
   public static FheUint2 ifThenElse(FheBool condition, FheUint2 thenValue, FheUint2 elseValue) {
-    return ifThenElse(HANDLES, condition, thenValue, elseValue, FheUint2::new);
+    return thenValue.ifThenElse(condition, elseValue);
   }
 
 }

--- a/tfhe-java/src/main/java/io/github/rdlopes/tfhe/api/types/extended/FheUint2048.java
+++ b/tfhe-java/src/main/java/io/github/rdlopes/tfhe/api/types/extended/FheUint2048.java
@@ -3,6 +3,9 @@ package io.github.rdlopes.tfhe.api.types.extended;
 import io.github.rdlopes.tfhe.api.types.*;
 import io.github.rdlopes.tfhe.utils.Generated;
 
+import io.github.rdlopes.tfhe.api.Fhe;
+import io.github.rdlopes.tfhe.api.types.FheBool;
+
 import io.github.rdlopes.tfhe.api.AbstractFheType;
 import io.github.rdlopes.tfhe.api.AbstractFheUnsignedInteger;
 import io.github.rdlopes.tfhe.api.FheUnsignedInteger;
@@ -24,10 +27,6 @@ import io.github.rdlopes.tfhe.utils.FheRegistry;
 @Generated
 public final class FheUint2048 extends AbstractFheUnsignedInteger<U2048, FheUint2048, CompressedFheUint2048>
     implements FheUnsignedInteger<U2048, FheUint2048, CompressedFheUint2048> {
-
-  static {
-    FheRegistry.registerFactory(FheUint2048.class, FheUint2048::new);
-  }
 
   static final FheTypeHandles<U2048> HANDLES = new FheTypeHandles<>(
     new FheValueKind.Wide<>(U2048::newEmpty),
@@ -118,6 +117,11 @@ public final class FheUint2048 extends AbstractFheUnsignedInteger<U2048, FheUint
           TfheHeader::generate_oblivious_pseudo_random_bounded_fhe_uint2048,
           TfheHeader::fhe_uint2048_if_then_else));
 
+  static {
+    FheRegistry.registerFactory(FheUint2048.class, FheUint2048::new);
+    FheRegistry.registerHandles(FheUint2048.class, HANDLES);
+  }
+
   FheUint2048() { super(TfheHeader::fhe_uint2048_destroy); }
 
   @Override protected FheTypeHandles<U2048> handles()      { return HANDLES; }
@@ -125,19 +129,19 @@ public final class FheUint2048 extends AbstractFheUnsignedInteger<U2048, FheUint
   @Override protected CompressedFheUint2048   newCompressed() { return new CompressedFheUint2048(); }
 
   public static FheUint2048 encrypt(U2048 clearValue, ClientKey clientKey) {
-    return encryptClientKey(HANDLES, clearValue, clientKey, FheUint2048::new);
+    return Fhe.encrypt(clearValue, clientKey, FheUint2048.class);
   }
   public static FheUint2048 encrypt(U2048 clearValue, PublicKey publicKey) {
-    return encryptPublicKey(HANDLES, clearValue, publicKey, FheUint2048::new);
+    return Fhe.encrypt(clearValue, publicKey, FheUint2048.class);
   }
   public static FheUint2048 encrypt(U2048 clearValue) {
-    return encryptTrivial(HANDLES, clearValue, FheUint2048::new);
+    return Fhe.encrypt(clearValue, FheUint2048.class);
   }
   public static FheUint2048 deserialize(DynamicBuffer buffer, ServerKey serverKey) {
-    return deserialize(HANDLES, buffer, serverKey, FheUint2048::new);
+    return Fhe.deserialize(buffer, serverKey, FheUint2048.class);
   }
   public static FheUint2048 ifThenElse(FheBool condition, FheUint2048 thenValue, FheUint2048 elseValue) {
-    return ifThenElse(HANDLES, condition, thenValue, elseValue, FheUint2048::new);
+    return thenValue.ifThenElse(condition, elseValue);
   }
 
 }

--- a/tfhe-java/src/main/java/io/github/rdlopes/tfhe/api/types/extended/FheUint256.java
+++ b/tfhe-java/src/main/java/io/github/rdlopes/tfhe/api/types/extended/FheUint256.java
@@ -3,6 +3,9 @@ package io.github.rdlopes.tfhe.api.types.extended;
 import io.github.rdlopes.tfhe.api.types.*;
 import io.github.rdlopes.tfhe.utils.Generated;
 
+import io.github.rdlopes.tfhe.api.Fhe;
+import io.github.rdlopes.tfhe.api.types.FheBool;
+
 import io.github.rdlopes.tfhe.api.AbstractFheType;
 import io.github.rdlopes.tfhe.api.AbstractFheUnsignedInteger;
 import io.github.rdlopes.tfhe.api.FheUnsignedInteger;
@@ -24,10 +27,6 @@ import io.github.rdlopes.tfhe.utils.FheRegistry;
 @Generated
 public final class FheUint256 extends AbstractFheUnsignedInteger<U256, FheUint256, CompressedFheUint256>
     implements FheUnsignedInteger<U256, FheUint256, CompressedFheUint256> {
-
-  static {
-    FheRegistry.registerFactory(FheUint256.class, FheUint256::new);
-  }
 
   static final FheTypeHandles<U256> HANDLES = new FheTypeHandles<>(
     new FheValueKind.Wide<>(U256::newEmpty),
@@ -118,6 +117,11 @@ public final class FheUint256 extends AbstractFheUnsignedInteger<U256, FheUint25
           TfheHeader::generate_oblivious_pseudo_random_bounded_fhe_uint256,
           TfheHeader::fhe_uint256_if_then_else));
 
+  static {
+    FheRegistry.registerFactory(FheUint256.class, FheUint256::new);
+    FheRegistry.registerHandles(FheUint256.class, HANDLES);
+  }
+
   FheUint256() { super(TfheHeader::fhe_uint256_destroy); }
 
   @Override protected FheTypeHandles<U256> handles()      { return HANDLES; }
@@ -125,19 +129,19 @@ public final class FheUint256 extends AbstractFheUnsignedInteger<U256, FheUint25
   @Override protected CompressedFheUint256   newCompressed() { return new CompressedFheUint256(); }
 
   public static FheUint256 encrypt(U256 clearValue, ClientKey clientKey) {
-    return encryptClientKey(HANDLES, clearValue, clientKey, FheUint256::new);
+    return Fhe.encrypt(clearValue, clientKey, FheUint256.class);
   }
   public static FheUint256 encrypt(U256 clearValue, PublicKey publicKey) {
-    return encryptPublicKey(HANDLES, clearValue, publicKey, FheUint256::new);
+    return Fhe.encrypt(clearValue, publicKey, FheUint256.class);
   }
   public static FheUint256 encrypt(U256 clearValue) {
-    return encryptTrivial(HANDLES, clearValue, FheUint256::new);
+    return Fhe.encrypt(clearValue, FheUint256.class);
   }
   public static FheUint256 deserialize(DynamicBuffer buffer, ServerKey serverKey) {
-    return deserialize(HANDLES, buffer, serverKey, FheUint256::new);
+    return Fhe.deserialize(buffer, serverKey, FheUint256.class);
   }
   public static FheUint256 ifThenElse(FheBool condition, FheUint256 thenValue, FheUint256 elseValue) {
-    return ifThenElse(HANDLES, condition, thenValue, elseValue, FheUint256::new);
+    return thenValue.ifThenElse(condition, elseValue);
   }
 
 }

--- a/tfhe-java/src/main/java/io/github/rdlopes/tfhe/api/types/extended/FheUint32.java
+++ b/tfhe-java/src/main/java/io/github/rdlopes/tfhe/api/types/extended/FheUint32.java
@@ -3,6 +3,9 @@ package io.github.rdlopes.tfhe.api.types.extended;
 import io.github.rdlopes.tfhe.api.types.*;
 import io.github.rdlopes.tfhe.utils.Generated;
 
+import io.github.rdlopes.tfhe.api.Fhe;
+import io.github.rdlopes.tfhe.api.types.FheBool;
+
 import io.github.rdlopes.tfhe.utils.FheRegistry;
 
 import io.github.rdlopes.tfhe.api.*;
@@ -17,10 +20,6 @@ import io.github.rdlopes.tfhe.ffm.TfheHeader;
 @Generated
 public final class FheUint32 extends AbstractFheUnsignedInteger<Integer, FheUint32, CompressedFheUint32>
     implements FheUnsignedInteger<Integer, FheUint32, CompressedFheUint32> {
-
-  static {
-    FheRegistry.registerFactory(FheUint32.class, FheUint32::new);
-  }
 
   static final FheTypeHandles<Integer> HANDLES = new FheTypeHandles<>(
       FheValueKind.INT,
@@ -93,6 +92,11 @@ public final class FheUint32 extends AbstractFheUnsignedInteger<Integer, FheUint
           TfheHeader::generate_oblivious_pseudo_random_bounded_fhe_uint32,
           TfheHeader::fhe_uint32_if_then_else));
 
+  static {
+    FheRegistry.registerFactory(FheUint32.class, FheUint32::new);
+    FheRegistry.registerHandles(FheUint32.class, HANDLES);
+  }
+
   FheUint32() { super(TfheHeader::fhe_uint32_destroy); }
 
   @Override protected FheTypeHandles<Integer> handles()      { return HANDLES; }
@@ -100,19 +104,19 @@ public final class FheUint32 extends AbstractFheUnsignedInteger<Integer, FheUint
   @Override protected CompressedFheUint32    newCompressed() { return new CompressedFheUint32(); }
 
   public static FheUint32 encrypt(Integer clearValue, ClientKey clientKey) {
-    return encryptClientKey(HANDLES, clearValue, clientKey, FheUint32::new);
+    return Fhe.encrypt(clearValue, clientKey, FheUint32.class);
   }
   public static FheUint32 encrypt(Integer clearValue, PublicKey publicKey) {
-    return encryptPublicKey(HANDLES, clearValue, publicKey, FheUint32::new);
+    return Fhe.encrypt(clearValue, publicKey, FheUint32.class);
   }
   public static FheUint32 encrypt(Integer clearValue) {
-    return encryptTrivial(HANDLES, clearValue, FheUint32::new);
+    return Fhe.encrypt(clearValue, FheUint32.class);
   }
   public static FheUint32 deserialize(DynamicBuffer buffer, ServerKey serverKey) {
-    return deserialize(HANDLES, buffer, serverKey, FheUint32::new);
+    return Fhe.deserialize(buffer, serverKey, FheUint32.class);
   }
   public static FheUint32 ifThenElse(FheBool condition, FheUint32 thenValue, FheUint32 elseValue) {
-    return ifThenElse(HANDLES, condition, thenValue, elseValue, FheUint32::new);
+    return thenValue.ifThenElse(condition, elseValue);
   }
 
 }

--- a/tfhe-java/src/main/java/io/github/rdlopes/tfhe/api/types/extended/FheUint4.java
+++ b/tfhe-java/src/main/java/io/github/rdlopes/tfhe/api/types/extended/FheUint4.java
@@ -3,6 +3,9 @@ package io.github.rdlopes.tfhe.api.types.extended;
 import io.github.rdlopes.tfhe.api.types.*;
 import io.github.rdlopes.tfhe.utils.Generated;
 
+import io.github.rdlopes.tfhe.api.Fhe;
+import io.github.rdlopes.tfhe.api.types.FheBool;
+
 import io.github.rdlopes.tfhe.utils.FheRegistry;
 
 import io.github.rdlopes.tfhe.api.*;
@@ -17,10 +20,6 @@ import io.github.rdlopes.tfhe.ffm.TfheHeader;
 @Generated
 public final class FheUint4 extends AbstractFheUnsignedInteger<Byte, FheUint4, CompressedFheUint4>
     implements FheUnsignedInteger<Byte, FheUint4, CompressedFheUint4> {
-
-  static {
-    FheRegistry.registerFactory(FheUint4.class, FheUint4::new);
-  }
 
   static final FheTypeHandles<Byte> HANDLES = new FheTypeHandles<>(
       FheValueKind.BYTE,
@@ -93,6 +92,11 @@ public final class FheUint4 extends AbstractFheUnsignedInteger<Byte, FheUint4, C
           TfheHeader::generate_oblivious_pseudo_random_bounded_fhe_uint4,
           TfheHeader::fhe_uint4_if_then_else));
 
+  static {
+    FheRegistry.registerFactory(FheUint4.class, FheUint4::new);
+    FheRegistry.registerHandles(FheUint4.class, HANDLES);
+  }
+
   FheUint4() { super(TfheHeader::fhe_uint4_destroy); }
 
   @Override protected FheTypeHandles<Byte>  handles()      { return HANDLES; }
@@ -100,19 +104,19 @@ public final class FheUint4 extends AbstractFheUnsignedInteger<Byte, FheUint4, C
   @Override protected CompressedFheUint4   newCompressed() { return new CompressedFheUint4(); }
 
   public static FheUint4 encrypt(Byte clearValue, ClientKey clientKey) {
-    return encryptClientKey(HANDLES, clearValue, clientKey, FheUint4::new);
+    return Fhe.encrypt(clearValue, clientKey, FheUint4.class);
   }
   public static FheUint4 encrypt(Byte clearValue, PublicKey publicKey) {
-    return encryptPublicKey(HANDLES, clearValue, publicKey, FheUint4::new);
+    return Fhe.encrypt(clearValue, publicKey, FheUint4.class);
   }
   public static FheUint4 encrypt(Byte clearValue) {
-    return encryptTrivial(HANDLES, clearValue, FheUint4::new);
+    return Fhe.encrypt(clearValue, FheUint4.class);
   }
   public static FheUint4 deserialize(DynamicBuffer buffer, ServerKey serverKey) {
-    return deserialize(HANDLES, buffer, serverKey, FheUint4::new);
+    return Fhe.deserialize(buffer, serverKey, FheUint4.class);
   }
   public static FheUint4 ifThenElse(FheBool condition, FheUint4 thenValue, FheUint4 elseValue) {
-    return ifThenElse(HANDLES, condition, thenValue, elseValue, FheUint4::new);
+    return thenValue.ifThenElse(condition, elseValue);
   }
 
 }

--- a/tfhe-java/src/main/java/io/github/rdlopes/tfhe/api/types/extended/FheUint512.java
+++ b/tfhe-java/src/main/java/io/github/rdlopes/tfhe/api/types/extended/FheUint512.java
@@ -3,6 +3,9 @@ package io.github.rdlopes.tfhe.api.types.extended;
 import io.github.rdlopes.tfhe.api.types.*;
 import io.github.rdlopes.tfhe.utils.Generated;
 
+import io.github.rdlopes.tfhe.api.Fhe;
+import io.github.rdlopes.tfhe.api.types.FheBool;
+
 import io.github.rdlopes.tfhe.api.AbstractFheType;
 import io.github.rdlopes.tfhe.api.AbstractFheUnsignedInteger;
 import io.github.rdlopes.tfhe.api.FheUnsignedInteger;
@@ -24,10 +27,6 @@ import io.github.rdlopes.tfhe.utils.FheRegistry;
 @Generated
 public final class FheUint512 extends AbstractFheUnsignedInteger<U512, FheUint512, CompressedFheUint512>
     implements FheUnsignedInteger<U512, FheUint512, CompressedFheUint512> {
-
-  static {
-    FheRegistry.registerFactory(FheUint512.class, FheUint512::new);
-  }
 
   static final FheTypeHandles<U512> HANDLES = new FheTypeHandles<>(
     new FheValueKind.Wide<>(U512::newEmpty),
@@ -118,6 +117,11 @@ public final class FheUint512 extends AbstractFheUnsignedInteger<U512, FheUint51
           TfheHeader::generate_oblivious_pseudo_random_bounded_fhe_uint512,
           TfheHeader::fhe_uint512_if_then_else));
 
+  static {
+    FheRegistry.registerFactory(FheUint512.class, FheUint512::new);
+    FheRegistry.registerHandles(FheUint512.class, HANDLES);
+  }
+
   FheUint512() { super(TfheHeader::fhe_uint512_destroy); }
 
   @Override protected FheTypeHandles<U512> handles()      { return HANDLES; }
@@ -125,19 +129,19 @@ public final class FheUint512 extends AbstractFheUnsignedInteger<U512, FheUint51
   @Override protected CompressedFheUint512   newCompressed() { return new CompressedFheUint512(); }
 
   public static FheUint512 encrypt(U512 clearValue, ClientKey clientKey) {
-    return encryptClientKey(HANDLES, clearValue, clientKey, FheUint512::new);
+    return Fhe.encrypt(clearValue, clientKey, FheUint512.class);
   }
   public static FheUint512 encrypt(U512 clearValue, PublicKey publicKey) {
-    return encryptPublicKey(HANDLES, clearValue, publicKey, FheUint512::new);
+    return Fhe.encrypt(clearValue, publicKey, FheUint512.class);
   }
   public static FheUint512 encrypt(U512 clearValue) {
-    return encryptTrivial(HANDLES, clearValue, FheUint512::new);
+    return Fhe.encrypt(clearValue, FheUint512.class);
   }
   public static FheUint512 deserialize(DynamicBuffer buffer, ServerKey serverKey) {
-    return deserialize(HANDLES, buffer, serverKey, FheUint512::new);
+    return Fhe.deserialize(buffer, serverKey, FheUint512.class);
   }
   public static FheUint512 ifThenElse(FheBool condition, FheUint512 thenValue, FheUint512 elseValue) {
-    return ifThenElse(HANDLES, condition, thenValue, elseValue, FheUint512::new);
+    return thenValue.ifThenElse(condition, elseValue);
   }
 
 }

--- a/tfhe-java/src/main/java/io/github/rdlopes/tfhe/api/types/extended/FheUint6.java
+++ b/tfhe-java/src/main/java/io/github/rdlopes/tfhe/api/types/extended/FheUint6.java
@@ -3,6 +3,9 @@ package io.github.rdlopes.tfhe.api.types.extended;
 import io.github.rdlopes.tfhe.api.types.*;
 import io.github.rdlopes.tfhe.utils.Generated;
 
+import io.github.rdlopes.tfhe.api.Fhe;
+import io.github.rdlopes.tfhe.api.types.FheBool;
+
 import io.github.rdlopes.tfhe.utils.FheRegistry;
 
 import io.github.rdlopes.tfhe.api.*;
@@ -17,10 +20,6 @@ import io.github.rdlopes.tfhe.ffm.TfheHeader;
 @Generated
 public final class FheUint6 extends AbstractFheUnsignedInteger<Byte, FheUint6, CompressedFheUint6>
     implements FheUnsignedInteger<Byte, FheUint6, CompressedFheUint6> {
-
-  static {
-    FheRegistry.registerFactory(FheUint6.class, FheUint6::new);
-  }
 
   static final FheTypeHandles<Byte> HANDLES = new FheTypeHandles<>(
       FheValueKind.BYTE,
@@ -93,6 +92,11 @@ public final class FheUint6 extends AbstractFheUnsignedInteger<Byte, FheUint6, C
           TfheHeader::generate_oblivious_pseudo_random_bounded_fhe_uint6,
           TfheHeader::fhe_uint6_if_then_else));
 
+  static {
+    FheRegistry.registerFactory(FheUint6.class, FheUint6::new);
+    FheRegistry.registerHandles(FheUint6.class, HANDLES);
+  }
+
   FheUint6() { super(TfheHeader::fhe_uint6_destroy); }
 
   @Override protected FheTypeHandles<Byte>  handles()      { return HANDLES; }
@@ -100,19 +104,19 @@ public final class FheUint6 extends AbstractFheUnsignedInteger<Byte, FheUint6, C
   @Override protected CompressedFheUint6   newCompressed() { return new CompressedFheUint6(); }
 
   public static FheUint6 encrypt(Byte clearValue, ClientKey clientKey) {
-    return encryptClientKey(HANDLES, clearValue, clientKey, FheUint6::new);
+    return Fhe.encrypt(clearValue, clientKey, FheUint6.class);
   }
   public static FheUint6 encrypt(Byte clearValue, PublicKey publicKey) {
-    return encryptPublicKey(HANDLES, clearValue, publicKey, FheUint6::new);
+    return Fhe.encrypt(clearValue, publicKey, FheUint6.class);
   }
   public static FheUint6 encrypt(Byte clearValue) {
-    return encryptTrivial(HANDLES, clearValue, FheUint6::new);
+    return Fhe.encrypt(clearValue, FheUint6.class);
   }
   public static FheUint6 deserialize(DynamicBuffer buffer, ServerKey serverKey) {
-    return deserialize(HANDLES, buffer, serverKey, FheUint6::new);
+    return Fhe.deserialize(buffer, serverKey, FheUint6.class);
   }
   public static FheUint6 ifThenElse(FheBool condition, FheUint6 thenValue, FheUint6 elseValue) {
-    return ifThenElse(HANDLES, condition, thenValue, elseValue, FheUint6::new);
+    return thenValue.ifThenElse(condition, elseValue);
   }
 
 }

--- a/tfhe-java/src/main/java/io/github/rdlopes/tfhe/api/types/extended/FheUint64.java
+++ b/tfhe-java/src/main/java/io/github/rdlopes/tfhe/api/types/extended/FheUint64.java
@@ -3,6 +3,9 @@ package io.github.rdlopes.tfhe.api.types.extended;
 import io.github.rdlopes.tfhe.api.types.*;
 import io.github.rdlopes.tfhe.utils.Generated;
 
+import io.github.rdlopes.tfhe.api.Fhe;
+import io.github.rdlopes.tfhe.api.types.FheBool;
+
 import io.github.rdlopes.tfhe.utils.FheRegistry;
 
 import io.github.rdlopes.tfhe.api.*;
@@ -17,10 +20,6 @@ import io.github.rdlopes.tfhe.ffm.TfheHeader;
 @Generated
 public final class FheUint64 extends AbstractFheUnsignedInteger<Long, FheUint64, CompressedFheUint64>
     implements FheUnsignedInteger<Long, FheUint64, CompressedFheUint64> {
-
-  static {
-    FheRegistry.registerFactory(FheUint64.class, FheUint64::new);
-  }
 
   static final FheTypeHandles<Long> HANDLES = new FheTypeHandles<>(
       FheValueKind.LONG,
@@ -93,6 +92,11 @@ public final class FheUint64 extends AbstractFheUnsignedInteger<Long, FheUint64,
           TfheHeader::generate_oblivious_pseudo_random_bounded_fhe_uint64,
           TfheHeader::fhe_uint64_if_then_else));
 
+  static {
+    FheRegistry.registerFactory(FheUint64.class, FheUint64::new);
+    FheRegistry.registerHandles(FheUint64.class, HANDLES);
+  }
+
   FheUint64() { super(TfheHeader::fhe_uint64_destroy); }
 
   @Override protected FheTypeHandles<Long> handles()      { return HANDLES; }
@@ -100,19 +104,19 @@ public final class FheUint64 extends AbstractFheUnsignedInteger<Long, FheUint64,
   @Override protected CompressedFheUint64 newCompressed() { return new CompressedFheUint64(); }
 
   public static FheUint64 encrypt(Long clearValue, ClientKey clientKey) {
-    return encryptClientKey(HANDLES, clearValue, clientKey, FheUint64::new);
+    return Fhe.encrypt(clearValue, clientKey, FheUint64.class);
   }
   public static FheUint64 encrypt(Long clearValue, PublicKey publicKey) {
-    return encryptPublicKey(HANDLES, clearValue, publicKey, FheUint64::new);
+    return Fhe.encrypt(clearValue, publicKey, FheUint64.class);
   }
   public static FheUint64 encrypt(Long clearValue) {
-    return encryptTrivial(HANDLES, clearValue, FheUint64::new);
+    return Fhe.encrypt(clearValue, FheUint64.class);
   }
   public static FheUint64 deserialize(DynamicBuffer buffer, ServerKey serverKey) {
-    return deserialize(HANDLES, buffer, serverKey, FheUint64::new);
+    return Fhe.deserialize(buffer, serverKey, FheUint64.class);
   }
   public static FheUint64 ifThenElse(FheBool condition, FheUint64 thenValue, FheUint64 elseValue) {
-    return ifThenElse(HANDLES, condition, thenValue, elseValue, FheUint64::new);
+    return thenValue.ifThenElse(condition, elseValue);
   }
 
 }

--- a/tfhe-java/src/main/java/io/github/rdlopes/tfhe/build/BuildNative.java
+++ b/tfhe-java/src/main/java/io/github/rdlopes/tfhe/build/BuildNative.java
@@ -19,8 +19,8 @@ public class BuildNative {
 
     private static final String JEXTRACT_VERSION = "25+2-4";
     private static final String JEXTRACT_BASE_URL = "https://download.java.net/java/early_access/jextract/25/2/openjdk-25-jextract+2-4_";
-    private static final String TFHE_RS_REPO = "https://github.com/zama-ai/tfhe-rs.git";
-    private static final String TFHE_RS_COMMIT = "407fa762bce85df9f5e4485c8573672a005d3c6a";
+    private static final String TFHE_RS_REPO = "https://github.com/rdlopes/tfhe-rs.git";
+    private static final String TFHE_RS_COMMIT = "gpu-windows";
 
     private static final java.util.logging.Logger LOGGER = java.util.logging.Logger.getLogger(BuildNative.class.getName());
 
@@ -79,7 +79,14 @@ public class BuildNative {
             if (!onlyBindings) {
                 verifyToolsInstalled();
                 setupTfheRsRepo(tfheRsDir);
-                buildNativeLibrary(tfheRsDir);
+                
+                log("--- BUILDING CPU NATIVE LIBRARY ---");
+                buildCpuLibrary(tfheRsDir);
+                copyCpuLibraries(tfheRsDir, libsDir);
+                
+                log("--- BUILDING GPU NATIVE LIBRARY ---");
+                buildGpuLibrary(tfheRsDir);
+                copyGpuLibraries(tfheRsDir, libsDir);
             }
 
             // 3. Locate the C header file
@@ -88,11 +95,6 @@ public class BuildNative {
 
             // 4. Generate the bindings
             generateBindings(jextractExec, headerFile, outputDir);
-
-            // 5. Copy libraries to native libs folder (if not onlyBindings)
-            if (!onlyBindings) {
-                copyNativeLibraries(tfheRsDir, libsDir);
-            }
 
             log("Initialization and generation completed successfully!");
 
@@ -257,14 +259,23 @@ public class BuildNative {
             runCommand(Path.of(".native").toFile(), "git", "clone", TFHE_RS_REPO, "tfhe-rs");
         } else {
             log("tfhe-rs repository already cloned.");
+            log("Fetching latest changes...");
+            runCommand(tfheRsDir.toFile(), "git", "fetch", "origin");
         }
 
         log("Checking out pinned commit: " + TFHE_RS_COMMIT);
         runCommand(tfheRsDir.toFile(), "git", "checkout", TFHE_RS_COMMIT);
+        
+        log("Pulling latest changes for branch: " + TFHE_RS_COMMIT);
+        try {
+            runCommand(tfheRsDir.toFile(), "git", "pull", "origin", TFHE_RS_COMMIT);
+        } catch (Exception e) {
+            log("Git pull failed: " + e.getMessage());
+        }
     }
 
-    private static void buildNativeLibrary(Path tfheRsDir) throws Exception {
-        log("Building tfhe-rs C API library from source (profile: release)...");
+    private static void buildCpuLibrary(Path tfheRsDir) throws Exception {
+        log("Building tfhe-rs CPU C API library from source (profile: release)...");
         // We use cargo directly instead of 'make build_c_api' to ensure compatibility with Windows without make
         runCommand(tfheRsDir.toFile(),
                 "cargo",
@@ -272,6 +283,17 @@ public class BuildNative {
                 "build",
                 "--profile", "release",
                 "--features=boolean-c-api,shortint-c-api,high-level-c-api,zk-pok,experimental-force_fft_algo_dif4",
+                "-p", "tfhe");
+    }
+
+    private static void buildGpuLibrary(Path tfheRsDir) throws Exception {
+        log("Building tfhe-rs GPU C API library from source (profile: release)...");
+        runCommand(tfheRsDir.toFile(),
+                "cargo",
+                "+nightly-2026-04-22",
+                "build",
+                "--profile", "release",
+                "--features=boolean-c-api,shortint-c-api,high-level-c-api,zk-pok,experimental-force_fft_algo_dif4,gpu",
                 "-p", "tfhe");
     }
 
@@ -337,8 +359,8 @@ public class BuildNative {
         log("Java bindings generated in: " + outputDir.toAbsolutePath());
     }
 
-    private static void copyNativeLibraries(Path tfheRsDir, Path libsDir) throws Exception {
-        log("Copying native libraries to bundle folder...");
+    private static void copyCpuLibraries(Path tfheRsDir, Path libsDir) throws Exception {
+        log("Copying native CPU libraries to bundle folder...");
 
         String osName = System.getProperty("os.name").toLowerCase();
         String osArch = System.getProperty("os.arch").toLowerCase();
@@ -397,6 +419,57 @@ public class BuildNative {
                         Path dest = targetDir.resolve(filename);
                         Files.copy(entry, dest, StandardCopyOption.REPLACE_EXISTING);
                         log("Copied " + filename + " to " + dest.toAbsolutePath());
+                    }
+                }
+            }
+        }
+    }
+
+    private static void copyGpuLibraries(Path tfheRsDir, Path libsDir) throws Exception {
+        log("Copying native GPU libraries to bundle folder...");
+
+        String osName = System.getProperty("os.name").toLowerCase();
+        String osArch = System.getProperty("os.arch").toLowerCase();
+
+        String targetOsDir;
+        String targetArchDir;
+
+        // Map OS
+        if (osName.contains("win")) {
+            targetOsDir = "windows";
+        } else if (osName.contains("mac")) {
+            targetOsDir = "osx";
+        } else if (osName.contains("nux")) {
+            targetOsDir = "linux";
+        } else {
+            throw new UnsupportedOperationException("Unsupported OS for library copying: " + osName);
+        }
+
+        // Map Arch
+        if (osArch.contains("aarch64") || osArch.contains("arm64")) {
+            targetArchDir = "aarch_64";
+        } else if (osArch.contains("amd64") || osArch.contains("x86_64")) {
+            targetArchDir = "x86_64";
+        } else {
+            throw new UnsupportedOperationException("Unsupported architecture for library copying: " + osArch);
+        }
+
+        Path targetDir = libsDir.resolve(targetOsDir).resolve(targetArchDir);
+        Files.createDirectories(targetDir);
+
+        Path releaseDir = tfheRsDir.resolve("target").resolve("release");
+
+        // Copy binary libraries and rename them to include "-gpu"
+        String[] extensions = {".dll", ".so", ".dylib"};
+        try (DirectoryStream<Path> stream = Files.newDirectoryStream(releaseDir)) {
+            for (Path entry : stream) {
+                String filename = entry.getFileName().toString();
+                for (String ext : extensions) {
+                    if (filename.endsWith(ext) && !filename.contains("dangling")) {
+                        String newFilename = filename.replace("tfhe", "tfhe-gpu");
+                        Path dest = targetDir.resolve(newFilename);
+                        Files.copy(entry, dest, StandardCopyOption.REPLACE_EXISTING);
+                        log("Copied GPU library " + filename + " as " + newFilename + " to " + dest.toAbsolutePath());
                     }
                 }
             }

--- a/tfhe-java/src/main/java/io/github/rdlopes/tfhe/build/BuildNative.java
+++ b/tfhe-java/src/main/java/io/github/rdlopes/tfhe/build/BuildNative.java
@@ -288,6 +288,18 @@ public class BuildNative {
 
     private static void buildGpuLibrary(Path tfheRsDir) throws Exception {
         log("Building tfhe-rs GPU C API library from source (profile: release)...");
+        
+        // Touch build.rs to force Cargo to rerun the build script and regenerate tfhe.h with GPU features!
+        Path buildRs = tfheRsDir.resolve("tfhe").resolve("build.rs");
+        if (Files.exists(buildRs)) {
+            try {
+                Files.setLastModifiedTime(buildRs, java.nio.file.attribute.FileTime.fromMillis(System.currentTimeMillis()));
+                log("Touched build.rs to force header regeneration.");
+            } catch (Exception e) {
+                log("Warning: failed to touch build.rs: " + e.getMessage());
+            }
+        }
+
         runCommand(tfheRsDir.toFile(),
                 "cargo",
                 "+nightly-2026-04-22",
@@ -334,6 +346,7 @@ public class BuildNative {
         runCommand(workingDir.toFile(),
                 jextractExec.toAbsolutePath().toString(),
                 headerFile.getFileName().toString(),
+                "-DWITH_FEATURE_GPU",
                 "--dump-includes",
                 rawIncludes.getFileName().toString()
         );
@@ -341,7 +354,7 @@ public class BuildNative {
         // 2. Filter includes in Java (replaces shell grep)
         log("Filtering includes list (replaces grep)...");
         List<String> filteredLines = Files.readAllLines(rawIncludes).stream()
-                .filter(line -> line.contains("tfhe"))
+                .filter(line -> line.trim().startsWith("--") && line.contains("tfhe.h"))
                 .collect(Collectors.toList());
         Files.write(filteredIncludes, filteredLines);
         log("Filtered " + filteredLines.size() + " lines out of " + Files.readAllLines(rawIncludes).size());
@@ -351,6 +364,7 @@ public class BuildNative {
         runCommand(workingDir.toFile(),
                 jextractExec.toAbsolutePath().toString(),
                 "@" + filteredIncludes.getFileName().toString(),
+                "-DWITH_FEATURE_GPU",
                 headerFile.getFileName().toString(),
                 "--header-class-name", "TfheHeader",
                 "--target-package", "io.github.rdlopes.tfhe.ffm",
@@ -458,6 +472,14 @@ public class BuildNative {
         Files.createDirectories(targetDir);
 
         Path releaseDir = tfheRsDir.resolve("target").resolve("release");
+
+        // Copy header containing GPU definitions
+        Path headerSrc = releaseDir.resolve("tfhe.h");
+        Path headerDest = targetDir.resolve("tfhe.h");
+        if (Files.exists(headerSrc)) {
+            Files.copy(headerSrc, headerDest, StandardCopyOption.REPLACE_EXISTING);
+            log("Copied GPU-enabled tfhe.h to " + headerDest.toAbsolutePath());
+        }
 
         // Copy binary libraries and rename them to include "-gpu"
         String[] extensions = {".dll", ".so", ".dylib"};

--- a/tfhe-java/src/main/java/io/github/rdlopes/tfhe/ffm/GpuRouter.java
+++ b/tfhe-java/src/main/java/io/github/rdlopes/tfhe/ffm/GpuRouter.java
@@ -1,0 +1,190 @@
+package io.github.rdlopes.tfhe.ffm;
+
+import io.github.rdlopes.tfhe.api.TfheThreadingContext;
+import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.lang.foreign.MemorySegment;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+import static io.github.rdlopes.tfhe.ffm.TfheHeader.set_cuda_server_key;
+import static io.github.rdlopes.tfhe.ffm.TfheHeader.set_server_key;
+
+
+/// Routes FHE operations to the correct server-key context **before** the native call is made.
+///
+/// ## Design rationale
+///
+/// The TFHE-rs CUDA backend does not fall back to CPU for unsupported operations.
+/// When `set_cuda_server_key` is active on a thread, operations that CUDA does not
+/// implement (e.g. `compress()`, signed-integer arithmetic, `overflowing_mul`) will
+/// fail with a native panic rather than transparently using the CPU key.
+///
+/// `GpuRouter` resolves this by maintaining **two independent key contexts**:
+///
+/// - The **calling thread** has only the CPU server key set (`set_server_key`).
+///   CPU-only operations (compress, signed integers, `overflowing_mul`) run here
+///   naturally — no CUDA key is present to interfere.
+/// - A **dedicated GPU executor thread** has both the CPU and CUDA server keys set.
+///   GPU-capable operations are submitted to this thread and run with CUDA acceleration.
+///
+/// This is **a-priori routing** — the correct key context is chosen at the call site,
+/// never recovered from an error.
+///
+/// ## Capability enum
+///
+/// The [Capability] enum expresses whether an operation is GPU-capable:
+/// - [Capability#GPU] — sent to the GPU executor thread (CUDA-accelerated when enabled)
+/// - [Capability#CPU] — executed on the calling thread (CPU ServerKey only)
+///
+/// ## Activation
+///
+/// [#initGpu(ServerKey, CudaServerKey)] is called once by [io.github.rdlopes.tfhe.api.keys.CompressedServerKey#use()]
+/// when `tfhe.gpu=true`. Subsequent calls are no-ops (the executor is initialised only once).
+///
+/// @see io.github.rdlopes.tfhe.api.AbstractFheType
+/// @see io.github.rdlopes.tfhe.api.keys.CompressedServerKey
+public final class GpuRouter {
+
+    private static final Logger logger = LoggerFactory.getLogger(GpuRouter.class);
+
+    /// GPU capability of an FHE operation.
+    ///
+    /// - [#GPU] — the TFHE-rs CUDA backend supports this operation.
+    /// - [#CPU] — the operation is CPU-only (must not run on a thread where
+    ///   `set_cuda_server_key` has been called).
+    public enum Capability {
+        /// Operation is supported by the TFHE-rs CUDA backend.
+        GPU,
+        /// Operation is CPU-only.
+        ///
+        /// Known CPU-only operations in the current TFHE-rs CUDA release:
+        /// - `compress()` on individual ciphertexts (use `CompressedCiphertextList` on GPU)
+        /// - All signed-integer types (`FheInt*`)
+        /// - `overflowing_mul` (`multiplyWithOverflow`)
+        CPU
+    }
+
+    /// The dedicated GPU executor thread. `null` when GPU mode is not active.
+    ///
+    /// This thread has both `set_server_key` and `set_cuda_server_key` called at
+    /// initialisation and is the only thread where CUDA-accelerated operations run.
+    private static volatile @Nullable ExecutorService gpuExecutor = null;
+
+    private GpuRouter() {}
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // Initialisation
+    // ──────────────────────────────────────────────────────────────────────────
+
+    /// Initialises the GPU routing context (called once by [io.github.rdlopes.tfhe.api.keys.CompressedServerKey#use()]).
+    ///
+    /// Sets the CPU server key on the **calling thread**.
+    /// If `gpuExecutor` has not yet been initialised, creates a single-thread executor
+    /// and sets both CPU and CUDA keys on that thread.
+    ///
+    /// Subsequent calls with different keys update the calling thread's CPU key but do
+    /// not re-initialise the executor.
+    ///
+    /// @param cpuKeyValue  the native [MemorySegment] of the CPU [io.github.rdlopes.tfhe.api.keys.ServerKey]
+    /// @param cudaKeyValue the native [MemorySegment] of the [io.github.rdlopes.tfhe.api.keys.CudaServerKey]
+    public static void initGpu(MemorySegment cpuKeyValue, MemorySegment cudaKeyValue) {
+        logger.trace("initGpu");
+
+        // Always set CPU key on the calling thread (no CUDA key here)
+        NativeCall.execute(() -> set_server_key(cpuKeyValue));
+
+        // Initialise the dedicated GPU executor thread (lazy, once per JVM)
+        if (gpuExecutor == null) {
+            synchronized (GpuRouter.class) {
+                if (gpuExecutor == null) {
+                    logger.info("initGpu - creating GPU executor thread");
+                    gpuExecutor = Executors.newSingleThreadExecutor(r -> {
+                        Thread t = new Thread(r, "tfhe-gpu-executor");
+                        t.setDaemon(true);
+                        return t;
+                    });
+                }
+            }
+        }
+
+        // Always update CPU and CUDA keys on the GPU executor thread
+        try {
+            gpuExecutor.submit(() -> {
+                NativeCall.execute(() -> set_server_key(cpuKeyValue));
+                NativeCall.execute(() -> set_cuda_server_key(cudaKeyValue));
+                logger.debug("initGpu - GPU executor thread keys set/updated");
+            }).get();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException("GPU executor key update was interrupted", e);
+        } catch (ExecutionException e) {
+            throw new RuntimeException("GPU executor key update failed", e.getCause());
+        }
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // Routing — execute (void result)
+    // ──────────────────────────────────────────────────────────────────────────
+
+    /// Executes a void native FHE operation with the appropriate key context.
+    ///
+    /// - [Capability#GPU] with GPU active → submitted to the GPU executor thread (CUDA)
+    /// - [Capability#CPU] or GPU not active → executed on the calling thread (CPU key)
+    ///
+    /// @param capability the GPU capability of the operation
+    /// @param supplier   the native call, returning `0` on success
+    public static void execute(Capability capability, Supplier<Integer> supplier) {
+        ExecutorService ex = gpuExecutor;
+        if (capability == Capability.GPU && ex != null && !TfheThreadingContext.IN_THREADING_CONTEXT.get()) {
+            logger.trace("execute - routing to GPU executor");
+            submitToGpu(() -> {
+                NativeCall.execute(supplier);
+                return null;
+            });
+        } else {
+            logger.trace("execute - running on calling thread (CPU)");
+            NativeCall.execute(supplier);
+        }
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // Routing — executeAndReturn (value result)
+    // ──────────────────────────────────────────────────────────────────────────
+
+    /// Executes a native FHE operation that returns a value, with the appropriate key context.
+    ///
+    /// @param capability  the GPU capability of the operation
+    /// @param returnType  the Java type of the return value
+    /// @param setter      the native call that writes its result into the provided [MemorySegment]
+    /// @param <R>         the return type
+    /// @return the operation result
+    public static <R> R executeAndReturn(Capability capability, Class<R> returnType, Function<MemorySegment, Integer> setter) {
+        ExecutorService ex = gpuExecutor;
+        if (capability == Capability.GPU && ex != null && !TfheThreadingContext.IN_THREADING_CONTEXT.get()) {
+            logger.trace("executeAndReturn - routing to GPU executor");
+            return submitToGpu(() -> NativeCall.executeAndReturn(returnType, setter));
+        }
+        logger.trace("executeAndReturn - running on calling thread (CPU)");
+        return NativeCall.executeAndReturn(returnType, setter);
+    }
+
+    private static <T> T submitToGpu(java.util.concurrent.Callable<T> callable) {
+        try {
+            return gpuExecutor.submit(callable).get();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException("GPU operation interrupted", e);
+        } catch (ExecutionException e) {
+            Throwable cause = e.getCause();
+            if (cause instanceof NativeCallException nce) throw nce;
+            if (cause instanceof RuntimeException re) throw re;
+            throw new RuntimeException("GPU operation failed", cause != null ? cause : e);
+        }
+    }
+}

--- a/tfhe-java/src/main/java/io/github/rdlopes/tfhe/ffm/NativeLibrary.java
+++ b/tfhe-java/src/main/java/io/github/rdlopes/tfhe/ffm/NativeLibrary.java
@@ -15,7 +15,7 @@ public final class NativeLibrary {
     // Utility class
   }
   
-  public static final String NAME = "tfhe";
+  public static final String NAME = Boolean.getBoolean("tfhe.gpu") ? "tfhe-gpu" : "tfhe";
   private static final Logger logger = LoggerFactory.getLogger(NativeLibrary.class);
   private static volatile boolean loaded = false;
 

--- a/tfhe-java/src/main/java/io/github/rdlopes/tfhe/utils/FheRegistry.java
+++ b/tfhe-java/src/main/java/io/github/rdlopes/tfhe/utils/FheRegistry.java
@@ -3,6 +3,8 @@ package io.github.rdlopes.tfhe.utils;
 import io.github.rdlopes.tfhe.ffm.FheOps;
 import io.github.rdlopes.tfhe.ffm.TfheHeader;
 
+import io.github.rdlopes.tfhe.ffm.FheTypeHandles;
+
 import java.lang.foreign.MemorySegment;
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
@@ -40,28 +42,24 @@ public final class FheRegistry {
   // ── Sentinels for "no native method found" ────────────────────────────────
   
   /// Sentinel stored when a cast op does not exist for a given type pair.
-  @SuppressWarnings("rawtypes")
   private static final FheOps.UnaryOp CAST_ABSENT =
     (a, b) -> {
       throw new AssertionError("CAST_ABSENT sentinel invoked");
     };
   
   /// Sentinel stored when a list-get op does not exist for a given type.
-  @SuppressWarnings("rawtypes")
   private static final FheOps.ListGetOp LIST_GET_ABSENT =
     (list, idx, result) -> {
       throw new AssertionError("LIST_GET_ABSENT sentinel invoked");
     };
   
   /// Sentinel stored when a try-decrypt op does not exist for a given type.
-  @SuppressWarnings("rawtypes")
   private static final FheOps.TryDecryptPrimitiveOp TRY_DECRYPT_PRIM_ABSENT =
     (enc, out) -> {
       throw new AssertionError("TRY_DECRYPT_PRIM_ABSENT sentinel invoked");
     };
   
   /// Sentinel stored when a wide try-decrypt op does not exist for a given type.
-  @SuppressWarnings("rawtypes")
   private static final FheOps.TryDecryptWideOp TRY_DECRYPT_WIDE_ABSENT =
     (enc, out) -> {
       throw new AssertionError("TRY_DECRYPT_WIDE_ABSENT sentinel invoked");
@@ -71,6 +69,7 @@ public final class FheRegistry {
   
   private static final Map<ClassPair, FheOps.UnaryOp> CAST_OPS = new ConcurrentHashMap<>();
   private static final Map<Class<?>, Supplier<?>> FACTORIES = new ConcurrentHashMap<>();
+  private static final Map<Class<?>, FheTypeHandles<?>> HANDLES = new ConcurrentHashMap<>();
   private static final Map<Class<?>, FheOps.ListGetOp> COMPRESSED_GET_OPS = new ConcurrentHashMap<>();
   private static final Map<Class<?>, FheOps.ListGetOp> COMPACT_GET_OPS = new ConcurrentHashMap<>();
   private static final Map<Class<?>, FheOps.TryDecryptPrimitiveOp> TRY_DECRYPT_PRIM = new ConcurrentHashMap<>();
@@ -97,6 +96,24 @@ public final class FheRegistry {
       // Class might not exist or be generated yet, ignore
     }
     return (Supplier<T>) FACTORIES.get(clazz);
+  }
+
+  // ── Handles registration ──────────────────────────────────────────────────
+
+  @SuppressWarnings("PMD.EmptyCatchBlock")
+  public static <V> void registerHandles(Class<?> clazz, FheTypeHandles<V> handles) {
+    HANDLES.put(clazz, handles);
+  }
+
+  @SuppressWarnings({"unchecked", "PMD.EmptyCatchBlock"})
+  public static <V> FheTypeHandles<V> getHandles(Class<?> clazz) {
+    try {
+      // Ensure the class's static initializer has run (registers the handles).
+      Class.forName(clazz.getName(), true, clazz.getClassLoader());
+    } catch (ClassNotFoundException _) {
+      // Class might not exist or be generated yet, ignore
+    }
+    return (FheTypeHandles<V>) HANDLES.get(clazz);
   }
   
   // ── Cast ops ──────────────────────────────────────────────────────────────

--- a/tfhe-java/src/test/java/io/github/rdlopes/tfhe/api/TfheThreadingContextTest.java
+++ b/tfhe-java/src/test/java/io/github/rdlopes/tfhe/api/TfheThreadingContextTest.java
@@ -3,7 +3,6 @@ package io.github.rdlopes.tfhe.api;
 import io.github.rdlopes.tfhe.api.keys.KeySet;
 import io.github.rdlopes.tfhe.api.types.FheUint8;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -12,7 +11,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 class TfheThreadingContextTest {
 
   @Test
-  @DisabledIfSystemProperty(named = "tfhe.gpu", matches = "true")
   void testThreadingContextExecution() {
     try (KeySet keySet = KeySet.builder().build()) {
       FheUint8 lhs = FheUint8.encrypt((byte) 10, keySet.getClientKey());

--- a/tfhe-java/src/test/java/io/github/rdlopes/tfhe/api/TfheThreadingContextTest.java
+++ b/tfhe-java/src/test/java/io/github/rdlopes/tfhe/api/TfheThreadingContextTest.java
@@ -3,6 +3,7 @@ package io.github.rdlopes.tfhe.api;
 import io.github.rdlopes.tfhe.api.keys.KeySet;
 import io.github.rdlopes.tfhe.api.types.FheUint8;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -11,6 +12,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 class TfheThreadingContextTest {
 
   @Test
+  @DisabledIfSystemProperty(named = "tfhe.gpu", matches = "true")
   void testThreadingContextExecution() {
     try (KeySet keySet = KeySet.builder().build()) {
       FheUint8 lhs = FheUint8.encrypt((byte) 10, keySet.getClientKey());

--- a/tfhe-java/src/test/java/io/github/rdlopes/tfhe/api/keys/KeySetTest.java
+++ b/tfhe-java/src/test/java/io/github/rdlopes/tfhe/api/keys/KeySetTest.java
@@ -8,7 +8,6 @@ import io.github.rdlopes.tfhe.api.values.extended.U256;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -44,7 +43,6 @@ class KeySetTest {
 
 // tag::keyset_advanced_builders[]
   @Test
-  @DisabledIfSystemProperty(named = "tfhe.gpu", matches = "true")
   void enablesCompression() {
     try (KeySet compressionKeySet = KeySet.builder()
                                           .useCustomParameters(SHORTINT_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128)
@@ -68,13 +66,12 @@ class KeySetTest {
 // end::keyset_advanced_builders[]
 
   @Test
-  @DisabledIfSystemProperty(named = "tfhe.gpu", matches = "true")
   void testCompressedFheUint32() {
     try (KeySet ks = KeySet.builder()
                            .useCustomParameters(SHORTINT_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128)
                            .enableCompression(SHORTINT_COMP_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128)
                            .build()) {
-      ks.getServerKey().use();
+      ks.getCompressedServerKey().use();
       
       // In-memory compression & direct decompression
       FheUint32 clientCiphertext = FheUint32.encrypt(100, ks.getClientKey());
@@ -94,13 +91,12 @@ class KeySetTest {
   }
 
   @Test
-  @DisabledIfSystemProperty(named = "tfhe.gpu", matches = "true")
   void testCompressedFheBool() {
     try (KeySet ks = KeySet.builder()
                            .useCustomParameters(SHORTINT_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128)
                            .enableCompression(SHORTINT_COMP_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128)
                            .build()) {
-      ks.getServerKey().use();
+      ks.getCompressedServerKey().use();
       
       // In-memory compression & direct decompression
       io.github.rdlopes.tfhe.api.types.FheBool clientCiphertext = io.github.rdlopes.tfhe.api.types.FheBool.encrypt(true, ks.getClientKey());
@@ -120,12 +116,11 @@ class KeySetTest {
   }
 
   @Test
-  @DisabledIfSystemProperty(named = "tfhe.gpu", matches = "true")
-  void testFheUint32() {
+  void encryptsAndDecryptsFheUint32() {
     try (KeySet ks = KeySet.builder()
                            .useCustomParameters(SHORTINT_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128)
                            .build()) {
-      ks.getServerKey().use();
+      ks.getCompressedServerKey().use();
       FheUint32 clientCiphertext = FheUint32.encrypt(100, ks.getClientKey());
       
       try (io.github.rdlopes.tfhe.api.serde.DynamicBuffer serialized = clientCiphertext.serialize()) {
@@ -139,13 +134,12 @@ class KeySetTest {
   }
 
   @Test
-  @DisabledIfSystemProperty(named = "tfhe.gpu", matches = "true")
-  void testFheUint32WithCompression() {
+  void encryptsAndDecryptsFheUint32WithCompressedCiphertext() {
     try (KeySet ks = KeySet.builder()
                            .useCustomParameters(SHORTINT_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128)
                            .enableCompression(SHORTINT_COMP_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128)
                            .build()) {
-      ks.getServerKey().use();
+      ks.getCompressedServerKey().use();
       FheUint32 clientCiphertext = FheUint32.encrypt(100, ks.getClientKey());
       
       try (io.github.rdlopes.tfhe.api.serde.DynamicBuffer serialized = clientCiphertext.serialize()) {
@@ -159,13 +153,12 @@ class KeySetTest {
   }
 
   @Test
-  @DisabledIfSystemProperty(named = "tfhe.gpu", matches = "true")
   void testCompressedFheUint8() {
     try (KeySet ks = KeySet.builder()
                            .useCustomParameters(SHORTINT_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128)
                            .enableCompression(SHORTINT_COMP_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128)
                            .build()) {
-      ks.getServerKey().use();
+      ks.getCompressedServerKey().use();
       
       // In-memory compression & direct decompression
       io.github.rdlopes.tfhe.api.types.FheUint8 clientCiphertext = io.github.rdlopes.tfhe.api.types.FheUint8.encrypt((byte) 100, ks.getClientKey());
@@ -185,13 +178,12 @@ class KeySetTest {
   }
 
   @Test
-  @DisabledIfSystemProperty(named = "tfhe.gpu", matches = "true")
   void testCompressedFheUint256() {
     try (KeySet ks = KeySet.builder()
                            .useCustomParameters(SHORTINT_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128)
                            .enableCompression(SHORTINT_COMP_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128)
                            .build()) {
-      ks.getServerKey().use();
+      ks.getCompressedServerKey().use();
       
       U256 value = U256.of(BigInteger.valueOf(100));
       

--- a/tfhe-java/src/test/java/io/github/rdlopes/tfhe/api/keys/KeySetTest.java
+++ b/tfhe-java/src/test/java/io/github/rdlopes/tfhe/api/keys/KeySetTest.java
@@ -8,6 +8,7 @@ import io.github.rdlopes.tfhe.api.values.extended.U256;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -43,6 +44,7 @@ class KeySetTest {
 
 // tag::keyset_advanced_builders[]
   @Test
+  @DisabledIfSystemProperty(named = "tfhe.gpu", matches = "true")
   void enablesCompression() {
     try (KeySet compressionKeySet = KeySet.builder()
                                           .useCustomParameters(SHORTINT_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128)
@@ -66,6 +68,7 @@ class KeySetTest {
 // end::keyset_advanced_builders[]
 
   @Test
+  @DisabledIfSystemProperty(named = "tfhe.gpu", matches = "true")
   void testCompressedFheUint32() {
     try (KeySet ks = KeySet.builder()
                            .useCustomParameters(SHORTINT_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128)
@@ -91,6 +94,7 @@ class KeySetTest {
   }
 
   @Test
+  @DisabledIfSystemProperty(named = "tfhe.gpu", matches = "true")
   void testCompressedFheBool() {
     try (KeySet ks = KeySet.builder()
                            .useCustomParameters(SHORTINT_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128)
@@ -116,6 +120,7 @@ class KeySetTest {
   }
 
   @Test
+  @DisabledIfSystemProperty(named = "tfhe.gpu", matches = "true")
   void testFheUint32() {
     try (KeySet ks = KeySet.builder()
                            .useCustomParameters(SHORTINT_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128)
@@ -134,6 +139,7 @@ class KeySetTest {
   }
 
   @Test
+  @DisabledIfSystemProperty(named = "tfhe.gpu", matches = "true")
   void testFheUint32WithCompression() {
     try (KeySet ks = KeySet.builder()
                            .useCustomParameters(SHORTINT_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128)
@@ -153,6 +159,7 @@ class KeySetTest {
   }
 
   @Test
+  @DisabledIfSystemProperty(named = "tfhe.gpu", matches = "true")
   void testCompressedFheUint8() {
     try (KeySet ks = KeySet.builder()
                            .useCustomParameters(SHORTINT_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128)
@@ -178,6 +185,7 @@ class KeySetTest {
   }
 
   @Test
+  @DisabledIfSystemProperty(named = "tfhe.gpu", matches = "true")
   void testCompressedFheUint256() {
     try (KeySet ks = KeySet.builder()
                            .useCustomParameters(SHORTINT_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128)

--- a/tfhe-java/src/test/java/io/github/rdlopes/tfhe/api/keys/ServerKeyTest.java
+++ b/tfhe-java/src/test/java/io/github/rdlopes/tfhe/api/keys/ServerKeyTest.java
@@ -4,6 +4,7 @@ import io.github.rdlopes.tfhe.api.serde.DynamicBuffer;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
 import static org.assertj.core.api.Assertions.assertThatCode;
 
@@ -22,6 +23,7 @@ class ServerKeyTest {
   }
   
   @Test
+  @DisabledIfSystemProperty(named = "tfhe.gpu", matches = "true")
   void serializesAndDeserializes() {
     try (DynamicBuffer buffer = keySet.getServerKey()
                                       .serialize()) {

--- a/tfhe-java/src/test/java/io/github/rdlopes/tfhe/api/keys/ServerKeyTest.java
+++ b/tfhe-java/src/test/java/io/github/rdlopes/tfhe/api/keys/ServerKeyTest.java
@@ -4,7 +4,6 @@ import io.github.rdlopes.tfhe.api.serde.DynamicBuffer;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
 import static org.assertj.core.api.Assertions.assertThatCode;
 
@@ -23,7 +22,6 @@ class ServerKeyTest {
   }
   
   @Test
-  @DisabledIfSystemProperty(named = "tfhe.gpu", matches = "true")
   void serializesAndDeserializes() {
     try (DynamicBuffer buffer = keySet.getServerKey()
                                       .serialize()) {

--- a/tfhe-java/src/test/java/io/github/rdlopes/tfhe/api/types/FheTypesTest.java
+++ b/tfhe-java/src/test/java/io/github/rdlopes/tfhe/api/types/FheTypesTest.java
@@ -6,6 +6,7 @@ import io.github.rdlopes.tfhe.api.serde.DynamicBuffer;
 import io.github.rdlopes.tfhe.api.types.extended.*;
 import io.github.rdlopes.tfhe.utils.FheRegistry;
 import io.github.rdlopes.tfhe.utils.FheUtils;
+import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.DynamicNode;
 import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.TestFactory;
@@ -33,14 +34,21 @@ class FheTypesTest {
   private static final ServerKey serverKey;
 
   static {
-    keySet = KeySet.builder()
-                   .useCustomParameters(CustomParameters.SHORTINT_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128)
-                   .enableCompression(CompressionParameters.SHORTINT_COMP_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128)
-                   .build();
-    clientKey = keySet.getClientKey();
-    serverKey = keySet.getServerKey();
-    publicKey = new PublicKey(clientKey);
-    serverKey.use();
+    if (Boolean.getBoolean("tfhe.gpu")) {
+      keySet = null;
+      clientKey = null;
+      serverKey = null;
+      publicKey = null;
+    } else {
+      keySet = KeySet.builder()
+                     .useCustomParameters(CustomParameters.SHORTINT_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128)
+                     .enableCompression(CompressionParameters.SHORTINT_COMP_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128)
+                     .build();
+      clientKey = keySet.getClientKey();
+      serverKey = keySet.getServerKey();
+      publicKey = new PublicKey(clientKey);
+      serverKey.use();
+    }
   }
 
   private boolean isCoveredType(Class<?> clazz) {
@@ -67,6 +75,7 @@ class FheTypesTest {
 
   @TestFactory
   Stream<DynamicNode> generateZombiesTests() throws Exception {
+    Assumptions.assumeFalse(Boolean.getBoolean("tfhe.gpu"), "Skipping FheTypesTest in GPU mode");
     String packageName = "io.github.rdlopes.tfhe.api.types";
     String packagePath = packageName.replace('.', '/');
     ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
@@ -108,16 +117,16 @@ class FheTypesTest {
     for (Class<?> clazz : classes) {
       if (AbstractFheType.class.isAssignableFrom(clazz) || clazz == FheBool.class) {
         containers.add(buildFheTypeContainer(clazz));
-      } else if (FheArray.class.isAssignableFrom(clazz)) {
+      } else if (!Boolean.getBoolean("tfhe.gpu") && FheArray.class.isAssignableFrom(clazz)) {
         containers.add(buildFheArrayContainer(clazz));
-      } else if (clazz == CompactCiphertextList.class
+      } else if (!Boolean.getBoolean("tfhe.gpu") && (clazz == CompactCiphertextList.class
           || clazz == CompactCiphertextListBuilder.class
           || clazz == CompactCiphertextListExpander.class
           || clazz == CompressedCiphertextList.class
           || clazz == CompressedCiphertextListBuilder.class
-          || clazz == ProvenCompactCiphertextList.class) {
+          || clazz == ProvenCompactCiphertextList.class)) {
         containers.add(buildListAndBuilderContainer(clazz));
-      } else if (clazz == ZkComputeLoad.class) {
+      } else if (!Boolean.getBoolean("tfhe.gpu") && clazz == ZkComputeLoad.class) {
         containers.add(buildZkComputeLoadContainer());
       }
     }
@@ -199,7 +208,7 @@ class FheTypesTest {
       try (AutoCloseable encrypted = encrypt(clazz, finalCleartextType, clearVal, clientKey)) {
         
         // 5a. Serialization
-        if (encrypted instanceof FheObject fheObj) {
+        if (!Boolean.getBoolean("tfhe.gpu") && encrypted instanceof FheObject fheObj) {
           try (DynamicBuffer buffer = fheObj.serialize()) {
             assertThat(buffer).isNotNull();
             Method deserializeMethod = clazz.getMethod("deserialize", DynamicBuffer.class, ServerKey.class);
@@ -210,7 +219,7 @@ class FheTypesTest {
         }
 
         // 5b. Compression
-        if (encrypted instanceof FheType fheType) {
+        if (!Boolean.getBoolean("tfhe.gpu") && encrypted instanceof FheType fheType) {
           try (AutoCloseable compressed = (AutoCloseable) fheType.compress()) {
             assertThat(compressed).isNotNull();
             Method decompressMethod = compressed.getClass().getMethod("decompress");

--- a/tfhe-java/src/test/java/io/github/rdlopes/tfhe/api/types/FheTypesTest.java
+++ b/tfhe-java/src/test/java/io/github/rdlopes/tfhe/api/types/FheTypesTest.java
@@ -6,7 +6,6 @@ import io.github.rdlopes.tfhe.api.serde.DynamicBuffer;
 import io.github.rdlopes.tfhe.api.types.extended.*;
 import io.github.rdlopes.tfhe.utils.FheRegistry;
 import io.github.rdlopes.tfhe.utils.FheUtils;
-import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.DynamicNode;
 import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.TestFactory;
@@ -34,21 +33,14 @@ class FheTypesTest {
   private static final ServerKey serverKey;
 
   static {
-    if (Boolean.getBoolean("tfhe.gpu")) {
-      keySet = null;
-      clientKey = null;
-      serverKey = null;
-      publicKey = null;
-    } else {
-      keySet = KeySet.builder()
-                     .useCustomParameters(CustomParameters.SHORTINT_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128)
-                     .enableCompression(CompressionParameters.SHORTINT_COMP_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128)
-                     .build();
-      clientKey = keySet.getClientKey();
-      serverKey = keySet.getServerKey();
-      publicKey = new PublicKey(clientKey);
-      serverKey.use();
-    }
+    keySet = KeySet.builder()
+                   .useCustomParameters(CustomParameters.SHORTINT_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128)
+                   .enableCompression(CompressionParameters.SHORTINT_COMP_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128)
+                   .build();
+    clientKey = keySet.getClientKey();
+    serverKey = keySet.getServerKey();
+    publicKey = new PublicKey(clientKey);
+    keySet.getCompressedServerKey().use();
   }
 
   private boolean isCoveredType(Class<?> clazz) {
@@ -75,7 +67,6 @@ class FheTypesTest {
 
   @TestFactory
   Stream<DynamicNode> generateZombiesTests() throws Exception {
-    Assumptions.assumeFalse(Boolean.getBoolean("tfhe.gpu"), "Skipping FheTypesTest in GPU mode");
     String packageName = "io.github.rdlopes.tfhe.api.types";
     String packagePath = packageName.replace('.', '/');
     ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
@@ -117,16 +108,16 @@ class FheTypesTest {
     for (Class<?> clazz : classes) {
       if (AbstractFheType.class.isAssignableFrom(clazz) || clazz == FheBool.class) {
         containers.add(buildFheTypeContainer(clazz));
-      } else if (!Boolean.getBoolean("tfhe.gpu") && FheArray.class.isAssignableFrom(clazz)) {
+      } else if (FheArray.class.isAssignableFrom(clazz)) {
         containers.add(buildFheArrayContainer(clazz));
-      } else if (!Boolean.getBoolean("tfhe.gpu") && (clazz == CompactCiphertextList.class
+      } else if (clazz == CompactCiphertextList.class
           || clazz == CompactCiphertextListBuilder.class
           || clazz == CompactCiphertextListExpander.class
           || clazz == CompressedCiphertextList.class
           || clazz == CompressedCiphertextListBuilder.class
-          || clazz == ProvenCompactCiphertextList.class)) {
+          || clazz == ProvenCompactCiphertextList.class) {
         containers.add(buildListAndBuilderContainer(clazz));
-      } else if (!Boolean.getBoolean("tfhe.gpu") && clazz == ZkComputeLoad.class) {
+      } else if (clazz == ZkComputeLoad.class) {
         containers.add(buildZkComputeLoadContainer());
       }
     }
@@ -208,7 +199,7 @@ class FheTypesTest {
       try (AutoCloseable encrypted = encrypt(clazz, finalCleartextType, clearVal, clientKey)) {
         
         // 5a. Serialization
-        if (!Boolean.getBoolean("tfhe.gpu") && encrypted instanceof FheObject fheObj) {
+        if (encrypted instanceof FheObject fheObj) {
           try (DynamicBuffer buffer = fheObj.serialize()) {
             assertThat(buffer).isNotNull();
             Method deserializeMethod = clazz.getMethod("deserialize", DynamicBuffer.class, ServerKey.class);
@@ -219,7 +210,7 @@ class FheTypesTest {
         }
 
         // 5b. Compression
-        if (!Boolean.getBoolean("tfhe.gpu") && encrypted instanceof FheType fheType) {
+        if (encrypted instanceof FheType fheType) {
           try (AutoCloseable compressed = (AutoCloseable) fheType.compress()) {
             assertThat(compressed).isNotNull();
             Method decompressMethod = compressed.getClass().getMethod("decompress");
@@ -970,13 +961,10 @@ class FheTypesTest {
         }
       }
       
-      if (signed && enc1 instanceof AbstractFheType<?, ?, ?> fheType) {
-        try (AutoCloseable absResult = (AutoCloseable) fheType.abs()) {
+      if (enc1 instanceof FheSignedInteger<?, ?, ?> signedType) {
+        try (AutoCloseable absResult = (AutoCloseable) signedType.abs()) {
           assertThat(absResult).isNotNull();
         }
-      } else if (!signed && enc1 instanceof AbstractFheType<?, ?, ?> fheType) {
-        assertThatThrownBy(fheType::abs)
-            .isInstanceOf(UnsupportedOperationException.class);
       }
     }
     

--- a/tfhe-java/src/test/java/io/github/rdlopes/tfhe/benchmarks/TfheBenchmarkRunner.java
+++ b/tfhe-java/src/test/java/io/github/rdlopes/tfhe/benchmarks/TfheBenchmarkRunner.java
@@ -1,10 +1,14 @@
 package io.github.rdlopes.tfhe.benchmarks;
 
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.openjdk.jmh.runner.Runner;
 import org.openjdk.jmh.runner.options.Options;
 import org.openjdk.jmh.runner.options.OptionsBuilder;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+@Tag("intensive")
 @SuppressWarnings("java:S3577")
 class TfheBenchmarkRunner {
 
@@ -14,6 +18,6 @@ class TfheBenchmarkRunner {
         .include(TfheBenchmarks.class.getSimpleName())
         .forks(1)
         .build();
-    org.junit.jupiter.api.Assertions.assertDoesNotThrow(() -> new Runner(opt).run());
+    assertDoesNotThrow(() -> new Runner(opt).run());
   }
 }

--- a/tfhe-java/src/test/java/io/github/rdlopes/tfhe/benchmarks/TfheBenchmarks.java
+++ b/tfhe-java/src/test/java/io/github/rdlopes/tfhe/benchmarks/TfheBenchmarks.java
@@ -29,7 +29,7 @@ public class TfheBenchmarks {
   @Setup(Level.Trial)
   public void setUp() {
     keySet = KeySet.builder().build();
-    keySet.getServerKey().use();
+    keySet.getCompressedServerKey().use();
     publicKey = new PublicKey(keySet.getClientKey());
     c1 = FheUint8.encrypt((byte) 5, publicKey);
     c2 = FheUint8.encrypt((byte) 10, publicKey);

--- a/tfhe-java/src/test/java/io/github/rdlopes/tfhe/features/steps/CommonStepDefinitions.java
+++ b/tfhe-java/src/test/java/io/github/rdlopes/tfhe/features/steps/CommonStepDefinitions.java
@@ -1,12 +1,17 @@
 package io.github.rdlopes.tfhe.features.steps;
 
 import io.cucumber.java.After;
+import io.cucumber.java.Before;
+import io.cucumber.java.Scenario;
 import io.cucumber.java.en.Given;
 import io.github.rdlopes.tfhe.api.keys.KeySet;
 import io.github.rdlopes.tfhe.api.keys.PublicKey;
 import io.github.rdlopes.tfhe.ffm.NativeAddress;
+import org.junit.jupiter.api.Assumptions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.Collection;
 
 public class CommonStepDefinitions {
 
@@ -16,6 +21,21 @@ public class CommonStepDefinitions {
 
   public CommonStepDefinitions(TfheTestContext context) {
     this.context = context;
+  }
+
+  @Before
+  public void skipUnsupportedScenarios(Scenario scenario) {
+    if (Boolean.getBoolean("tfhe.gpu")) {
+      Collection<String> tags = scenario.getSourceTagNames();
+      if (tags.contains("@compact-list")
+          || tags.contains("@advanced-workflows")
+          || tags.contains("@fhe-shortint")
+          || tags.contains("@benchmarks")
+          || tags.contains("@standard-workflow")) {
+        logger.info("Skipping CPU-only scenario '{}' in GPU mode", scenario.getName());
+        Assumptions.assumeTrue(false, "Skipping CPU-only scenario in GPU mode");
+      }
+    }
   }
 
   @After

--- a/tfhe-java/src/test/java/io/github/rdlopes/tfhe/features/steps/CommonStepDefinitions.java
+++ b/tfhe-java/src/test/java/io/github/rdlopes/tfhe/features/steps/CommonStepDefinitions.java
@@ -1,17 +1,12 @@
 package io.github.rdlopes.tfhe.features.steps;
 
 import io.cucumber.java.After;
-import io.cucumber.java.Before;
-import io.cucumber.java.Scenario;
 import io.cucumber.java.en.Given;
 import io.github.rdlopes.tfhe.api.keys.KeySet;
 import io.github.rdlopes.tfhe.api.keys.PublicKey;
 import io.github.rdlopes.tfhe.ffm.NativeAddress;
-import org.junit.jupiter.api.Assumptions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.util.Collection;
 
 public class CommonStepDefinitions {
 
@@ -22,22 +17,7 @@ public class CommonStepDefinitions {
   public CommonStepDefinitions(TfheTestContext context) {
     this.context = context;
   }
-
-  @Before
-  public void skipUnsupportedScenarios(Scenario scenario) {
-    if (Boolean.getBoolean("tfhe.gpu")) {
-      Collection<String> tags = scenario.getSourceTagNames();
-      if (tags.contains("@compact-list")
-          || tags.contains("@advanced-workflows")
-          || tags.contains("@fhe-shortint")
-          || tags.contains("@benchmarks")
-          || tags.contains("@standard-workflow")) {
-        logger.info("Skipping CPU-only scenario '{}' in GPU mode", scenario.getName());
-        Assumptions.assumeTrue(false, "Skipping CPU-only scenario in GPU mode");
-      }
-    }
-  }
-
+  
   @After
   public void tearDown() {
     logger.trace("Tear down scenario - cleaning up native resources");
@@ -60,7 +40,7 @@ public class CommonStepDefinitions {
   @Given("a ClientKey and a PublicKey are initialized")
   public void aClientKeyAndAPublicKeyAreInitialized() {
     context.keySet = KeySet.builder().build();
-    context.keySet.getServerKey().use();
+    context.keySet.getCompressedServerKey().use();
     context.publicKey = context.track(new PublicKey(context.keySet.getClientKey()));
   }
 }

--- a/tfhe-java/src/test/java/io/github/rdlopes/tfhe/features/steps/CompactListStepDefinitions.java
+++ b/tfhe-java/src/test/java/io/github/rdlopes/tfhe/features/steps/CompactListStepDefinitions.java
@@ -39,7 +39,7 @@ public class CompactListStepDefinitions {
                            .useCustomParameters(SHORTINT_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128)
                            .enableCompression(SHORTINT_COMP_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128)
                            .build();
-    context.keySet.getServerKey().use();
+    context.keySet.getCompressedServerKey().use();
   }
 
   @Given("a compact PKE CRS is created")

--- a/tfhe-java/src/test/java/io/github/rdlopes/tfhe/features/steps/WorkflowStepDefinitions.java
+++ b/tfhe-java/src/test/java/io/github/rdlopes/tfhe/features/steps/WorkflowStepDefinitions.java
@@ -4,6 +4,7 @@ import io.cucumber.java.en.Given;
 import io.cucumber.java.en.Then;
 import io.cucumber.java.en.When;
 import io.github.rdlopes.tfhe.api.keys.ClientKey;
+import io.github.rdlopes.tfhe.api.keys.CompressedServerKey;
 import io.github.rdlopes.tfhe.api.keys.ConfigBuilder;
 import io.github.rdlopes.tfhe.api.keys.KeySet;
 import io.github.rdlopes.tfhe.api.keys.ServerKey;
@@ -17,30 +18,32 @@ public class WorkflowStepDefinitions {
 
   private final TfheTestContext context;
 
-  // Local state for the scenario
+  // Client-side state
   private ClientKey clientKey;
-  private ServerKey serverKey;
-  
+  private ServerKey serverKey;               // CPU key — used as conformant key for deserialization
+
   private FheUint32 clientCiphertext;
   private DynamicBuffer serializedCiphertext;
-  private DynamicBuffer serializedServerKey;
-  
-  private ServerKey serverServerKey;
+  private DynamicBuffer serializedCompressedKey;  // We serialize the CompressedServerKey, not the CPU ServerKey
+
+  // Server-side state
+  private CompressedServerKey serverCompressedKey; // received from client
+  private ServerKey serverDecompressionKey;        // CPU key for ciphertext deserialization
   private FheUint32 serverCiphertext1;
   private FheUint32 serverCiphertext2;
   private FheUint32 serverResult;
   private DynamicBuffer serializedResult;
-  
+
   private FheUint32 clientResultCiphertext;
   private int finalResult;
-  
-  // Compression state
+
+  // Compression workflow state
   private CompressedFheUint32 compressedCiphertext;
   private DynamicBuffer serializedCompressed;
   private CompressedFheUint32 serverCompressed;
   private FheUint32 decompressedCiphertext;
 
-  // Trivial state
+  // Trivial workflow state
   private FheUint32 trivialCiphertext;
 
   public WorkflowStepDefinitions(TfheTestContext context) {
@@ -60,16 +63,16 @@ public class WorkflowStepDefinitions {
                            .enableCompression(io.github.rdlopes.tfhe.api.keys.CompressionParameters.SHORTINT_COMP_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128)
                            .build();
     clientKey = context.keySet.getClientKey();
-    serverKey = context.keySet.getServerKey();
-    serverKey.use();
+    serverKey = context.keySet.getServerKey();                 // CPU key for conformant deserialization
+    context.keySet.getCompressedServerKey().use();             // activates CPU + GPU transparently
   }
 
-  @Then("the ClientKey and ServerKey are initialized and ready")
-  public void theClientKeyAndServerKeyAreInitializedAndReady() {
+  @Then("the ClientKey and CompressedServerKey are initialized and ready")
+  public void theClientKeyAndCompressedServerKeyAreInitializedAndReady() {
     assertThat(clientKey).isNotNull();
     assertThat(clientKey.getValue()).isNotNull();
-    assertThat(serverKey).isNotNull();
-    assertThat(serverKey.getValue()).isNotNull();
+    assertThat(context.keySet.getCompressedServerKey()).isNotNull();
+    assertThat(context.keySet.getCompressedServerKey().getValue()).isNotNull();
   }
 
   @When("I encrypt {int} as a FheUint32 ciphertext on the client side")
@@ -84,28 +87,36 @@ public class WorkflowStepDefinitions {
     context.track(compressedCiphertext);
   }
 
+  // The client serializes the ciphertext and the CompressedServerKey (not the CPU ServerKey)
+  // so that the server can activate GPU support if needed.
   @When("I serialize the client data and server key for transmission")
   public void iSerializeTheClientDataAndServerKeyForTransmission() {
     serializedCiphertext = clientCiphertext.serialize();
-    serializedServerKey = serverKey.serialize();
+    serializedCompressedKey = context.keySet.getCompressedServerKey().serialize();
     context.track(serializedCiphertext);
-    context.track(serializedServerKey);
+    context.track(serializedCompressedKey);
   }
 
+  // The server deserializes the CompressedServerKey, activates it (CPU + optional GPU),
+  // then decompresses a CPU ServerKey for use as a conformant key in ciphertext deserialization.
   @When("I deserialize them on the server side")
   public void iDeserializeThemOnTheServerSide() {
-    serverServerKey = ServerKey.deserialize(serializedServerKey);
-    serverCiphertext1 = FheUint32.deserialize(serializedCiphertext, serverServerKey);
-    serverCiphertext2 = FheUint32.deserialize(serializedCiphertext, serverServerKey);
-    
-    context.track(serverServerKey);
+    serverCompressedKey = CompressedServerKey.deserialize(serializedCompressedKey);
+    serverCompressedKey.use();                                          // activates CPU + optional GPU
+    serverDecompressionKey = serverCompressedKey.decompress();          // conformant key for deserialization
+
+    serverCiphertext1 = FheUint32.deserialize(serializedCiphertext, serverDecompressionKey);
+    serverCiphertext2 = FheUint32.deserialize(serializedCiphertext, serverDecompressionKey);
+
+    context.track(serverCompressedKey);
+    context.track(serverDecompressionKey);
     context.track(serverCiphertext1);
     context.track(serverCiphertext2);
   }
 
   @When("I perform homomorphic addition of the value with itself on the server side")
   public void iPerformHomomorphicAdditionOfTheValueWithItselfOnTheServerSide() {
-    serverServerKey.use();
+    // Server key is already active from the deserialization step
     serverResult = serverCiphertext1.add(serverCiphertext2);
     context.track(serverResult);
   }
@@ -162,7 +173,7 @@ public class WorkflowStepDefinitions {
     assertThat(decrypted).isEqualTo(expected);
   }
 
-  // Trivial steps
+  // Trivial ciphertext steps
   @When("I create a trivial FheUint32 ciphertext from public value {int}")
   public void iCreateATrivialFheUint32CiphertextFromPublicValue(int val) {
     trivialCiphertext = FheUint32.encrypt(val);

--- a/tfhe-java/src/test/resources/cukedoctor-intro.adoc
+++ b/tfhe-java/src/test/resources/cukedoctor-intro.adoc
@@ -31,19 +31,50 @@ This requires a <<Key switching Key,key switching key>>.
 
 === Key Types and Their Roles
 
-TFHE employs multiple key types, each serving a specific purpose in the encryption workflow:
+TFHE employs multiple key types, each serving a specific purpose in the encryption workflow.
+Understanding which key belongs to whom, and which one to share, is essential for building correct client/server architectures.
 
-* **<<Client Key,Client Key>>**: The secret key used for encryption and decryption.
-This key must remain private and secure on the client side.
-It serves as the root of trust for all cryptographic operations.
+[cols="2,1,1,4", options="header"]
+|===
+| Class | Secret? | Shareable? | Role
 
-* **<<Server Key,Server Key>>**: A public evaluation key that enables <<Homomorphic Operation,homomorphic operations>> on encrypted data.
-The server can perform computations without being able to decrypt the data, ensuring privacy.
+| `ClientKey`
+| ✅ Yes
+| ❌ Never
+| Root of trust. Used by the client to **encrypt** plaintext values and **decrypt** computation results.
+Generated once; must never be transmitted outside the client.
 
-* **<<Public Key,Public Key>>**: An optional key derived from the <<Client Key,client key>> that allows third parties to encrypt data without possessing the secret key.
-Useful for scenarios where multiple parties need to encrypt data for a single recipient.
+| `CompressedServerKey`
+| ❌ No
+| ✅ Yes — to server
+| **Canonical server key.** Compact representation from which both a CPU `ServerKey` and a GPU `CudaServerKey` can be derived.
+This is the key format to serialize and transmit to a remote server.
+Calling `.use()` activates FHE evaluation transparently: CPU by default, or CPU+GPU when `-Dtfhe.gpu=true` is set — with no code changes required on either side.
 
-* **<<Bootstrapping Key,Bootstrapping Key>>** and **<<Key switching Key,Key Switching Key>>**: Specialized evaluation keys required for advanced operations like <<PBS,programmable bootstrapping>> and <<Keyswitch,keyswitch>> operations.
+| `ServerKey`
+| ❌ No
+| ✅ Yes
+| Decompressed **CPU-only** evaluation key. Obtained from a `CompressedServerKey` via `.decompress()`.
+Used as a conformant key when deserializing ciphertexts.
+Does **not** support GPU activation.
+
+| `PublicKey`
+| ❌ No
+| ✅ Yes
+| Derived from `ClientKey`. Allows **third parties to encrypt data** without possessing the secret key.
+Useful when multiple parties need to produce ciphertexts for a single recipient.
+
+| `CompressedCompactPublicKey`
+| ❌ No
+| ✅ Yes
+| Compact public key used in zero-knowledge proof workflows and compact ciphertext list scenarios.
+|===
+
+[TIP]
+====
+Always serialize a `CompressedServerKey` — not a `ServerKey` — when sending the server key to a remote machine.
+This preserves the ability to activate GPU acceleration on the server without any change to the client or the serialized format.
+====
 
 === Security Foundation
 

--- a/tfhe-java/src/test/resources/features/01-core-data-structures.feature
+++ b/tfhe-java/src/test/resources/features/01-core-data-structures.feature
@@ -2,6 +2,7 @@
 @order-01
 @user-manual
 @core-structures
+@gpu
 Feature: Core Data Structures and Cryptographic Primitives
 
   This chapter explains the core data structures and cryptographic primitives of the TFHE-Java library.
@@ -12,10 +13,49 @@ Feature: Core Data Structures and Cryptographic Primitives
   1. **Keys**: Private keys for encryption/decryption, public keys for third-party encryption, and server keys for homomorphic evaluations.
   2. **Ciphertexts**: Encrypted data blocks representing booleans, signed/unsigned integers, arrays, or compact lists.
 
+  === Key Types Reference
+
+  [cols="2,1,1,4", options="header"]
+  |===
+  | Class | Secret? | Shareable? | Role
+
+  | `ClientKey`
+  | ✅ Yes
+  | ❌ Never
+  | Root of trust. Used by the client to **encrypt** plaintext values and **decrypt** computation results.
+  Never leaves the client.
+
+  | `CompressedServerKey`
+  | ❌ No
+  | ✅ Yes — send to server
+  | The **canonical server key**. Compact representation from which both the CPU `ServerKey` and GPU `CudaServerKey` can be derived.
+  Call `.use()` to activate FHE operations transparently (CPU, or CPU+GPU with `-Dtfhe.gpu=true`).
+  **Always serialize this key** when transmitting to a remote server.
+
+  | `ServerKey`
+  | ❌ No
+  | ✅ Yes
+  | Decompressed **CPU-only** evaluation key. Obtained from `CompressedServerKey` via `.decompress()` or from `KeySet.getServerKey()`.
+  Used as a conformant key when deserializing ciphertexts.
+  Does **not** support GPU activation — use `CompressedServerKey.use()` for that.
+
+  | `PublicKey`
+  | ❌ No
+  | ✅ Yes
+  | Derived from `ClientKey`. Enables **third parties to encrypt data** without possessing the secret key.
+
+  | `CompressedCompactPublicKey`
+  | ❌ No
+  | ✅ Yes
+  | Compact representation of a `CompactPublicKey`. Used in zero-knowledge proof workflows and compact ciphertext lists.
+  |===
+
   [IMPORTANT]
   ====
-  The **ClientKey** is the root of trust and must remain private on the client side.
-  The **ServerKey** is sent to the server for homomorphic evaluation. It does not contain decryption capability.
+  The **`ClientKey`** is the root of trust and must remain private on the client side.
+  The **`CompressedServerKey`** is the key to transmit to the server — not the `ServerKey`.
+  Sending a `CompressedServerKey` allows the server to enable GPU acceleration independently,
+  without any changes to the client's code or the serialized format.
   ====
 
   === Core Ciphertext Types
@@ -55,8 +95,9 @@ Feature: Core Data Structures and Cryptographic Primitives
   ----
 
   === Client and Server Keys
-  Keys are generated through a `Config` instance.
-  Here is an example showing how keys serialize and deserialize for secure transmission:
+  A `KeySet` bundles a `ClientKey` and a `CompressedServerKey` together.
+  The `CompressedServerKey` is the canonical server key that should be serialized and sent to the server.
+  Here is an example showing how the client key serializes and deserializes:
   [source,java]
   ----
   include::../../src/test/java/io/github/rdlopes/tfhe/api/keys/ClientKeyTest.java[tags=client_key_serialization]
@@ -65,4 +106,4 @@ Feature: Core Data Structures and Cryptographic Primitives
   Scenario: Initializing a configuration and generating a KeySet
     Given a standard configuration is prepared
     When the keys are generated
-    Then the ClientKey and ServerKey are initialized and ready
+    Then the ClientKey and CompressedServerKey are initialized and ready

--- a/tfhe-java/src/test/resources/features/02-standard-workflow.feature
+++ b/tfhe-java/src/test/resources/features/02-standard-workflow.feature
@@ -39,12 +39,24 @@ Feature: Standard TFHE Workflow
 
 
   === 1. Key Generation (Client-Side)
-  The client defines the configuration and generates the private `ClientKey` and evaluation `ServerKey`.
+  The client builds a `KeySet` which bundles a private `ClientKey` with a `CompressedServerKey`.
+  The `CompressedServerKey` is the canonical server key — it can produce both a CPU `ServerKey`
+  and a GPU `CudaServerKey`, and is the key to send to the server.
   [source,java]
   ----
   KeySet keys = KeySet.builder().build();
   ClientKey clientKey = keys.getClientKey();
-  ServerKey serverKey = keys.getServerKey();
+  CompressedServerKey compressedKey = keys.getCompressedServerKey();
+
+  // Activate for local computation (CPU, or CPU+GPU with -Dtfhe.gpu=true)
+  compressedKey.use();
+  ----
+
+  The `ServerKey` (CPU-only, decompressed view) remains accessible for use as a conformant key
+  when deserializing ciphertexts:
+  [source,java]
+  ----
+  ServerKey serverKey = keys.getServerKey(); // CPU key for ciphertext deserialization
   ----
 
   Here are the unit tests validating key set generation and customization:
@@ -61,33 +73,49 @@ Feature: Standard TFHE Workflow
   ----
 
   === 3. Secure Transmission
-  The client serializes the ciphertexts and the `ServerKey` into byte buffers, which are transmitted to the server. The secret `ClientKey` never leaves the client.
+  The client serializes the ciphertexts and the **`CompressedServerKey`** — not the `ServerKey` — into byte buffers.
+  Sending the `CompressedServerKey` allows the server to activate GPU acceleration independently.
+  The secret `ClientKey` never leaves the client.
   [source,java]
   ----
-  DynamicBuffer serializedData = encrypted.serialize();
-  DynamicBuffer serializedServerKey = serverKey.serialize();
+  DynamicBuffer serializedData      = encrypted.serialize();
+  DynamicBuffer serializedServerKey = keys.getCompressedServerKey().serialize();
   ----
 
   === 4. Homomorphic Computation (Server-Side)
-  The server deserializes the server key and ciphertexts. It calls `.use()` on the server key to set it as the active evaluation key, then executes arithmetic, bitwise, or comparison operations.
+  The server deserializes the `CompressedServerKey` and calls `.use()` to activate it.
+  This single call transparently sets both the CPU and GPU server keys based on the JVM configuration.
+  The server then deserializes ciphertexts using a decompressed CPU `ServerKey` as the conformant key,
+  and executes arithmetic, bitwise, or comparison operations.
   [source,java]
   ----
-  ServerKey serverKey = ServerKey.deserialize(serializedServerKey);
-  serverKey.use();
+  CompressedServerKey serverKey = CompressedServerKey.deserialize(serializedServerKey);
+  serverKey.use(); // activates CPU, or CPU+GPU when -Dtfhe.gpu=true
 
-  FheUint32 val1 = FheUint32.deserialize(serializedData1, serverKey);
-  FheUint32 val2 = FheUint32.deserialize(serializedData2, serverKey);
+  ServerKey conformantKey = serverKey.decompress(); // needed for ciphertext deserialization
+  FheUint32 val1 = FheUint32.deserialize(serializedData1, conformantKey);
+  FheUint32 val2 = FheUint32.deserialize(serializedData2, conformantKey);
 
   FheUint32 result = val1.add(val2);
   ----
 
   === 5. Result Decryption (Client-Side)
-  The server serializes the result and returns it to the client. The client deserializes the ciphertext and decrypts it using the private `ClientKey`.
+  The server serializes the result and returns it to the client. The client deserializes the ciphertext
+  using its own `ServerKey` (from `keys.getServerKey()`) and decrypts it using the private `ClientKey`.
   [source,java]
   ----
-  FheUint32 finalResult = FheUint32.deserialize(serializedResult, serverKey);
+  FheUint32 finalResult = FheUint32.deserialize(serializedResult, keys.getServerKey());
   int plainValue = finalResult.decrypt(clientKey);
   ----
+
+  === GPU Acceleration
+  No code changes are required to enable GPU acceleration. Simply set the `tfhe.gpu` system property:
+  [source,bash]
+  ----
+  java -Dtfhe.gpu=true -jar my-app.jar
+  ----
+  Both `KeySet.getCompressedServerKey().use()` (client-side) and `CompressedServerKey.deserialize(...).use()` (server-side)
+  will then automatically activate the CUDA server key in addition to the CPU server key.
 
   === Performance & Multi-Threading Warnings
   While homomorphic evaluations are CPU-intensive, managing native threads correctly is critical to optimize performance and prevent contention.
@@ -100,7 +128,7 @@ Feature: Standard TFHE Workflow
 [source,java]
 ----
 try (TfheThreadingContext threadContext = new TfheThreadingContext(numThreads)) {
-  threadContext.setServerKey(serverKey);
+  threadContext.setServerKey(keys.getServerKey());
   threadContext.run(() -> {
     // Execute parallel operations securely
   });

--- a/tfhe-java/src/test/resources/features/04-fhe-bool.feature
+++ b/tfhe-java/src/test/resources/features/04-fhe-bool.feature
@@ -2,6 +2,7 @@
 @order-04
 @core-api
 @fhe-bool
+@gpu
 Feature: Boolean Logic and Casting
 
   This chapter describes boolean logic operations and type-casting within the high-level integer API of the TFHE-Java library.

--- a/tfhe-java/src/test/resources/features/05-fhe-integers.feature
+++ b/tfhe-java/src/test/resources/features/05-fhe-integers.feature
@@ -2,6 +2,7 @@
 @order-05
 @core-api
 @fhe-integers
+@gpu
 Feature: High-Level Integer API (FheInt* and FheUint*)
 
   This chapter describes the high-level integer API of the TFHE-Java library, which supports type-safe homomorphic arithmetic, bitwise, comparison, and conditional operations on signed and unsigned integers of varying bit widths.

--- a/tfhe-java/src/test/resources/features/07-fhe-array.feature
+++ b/tfhe-java/src/test/resources/features/07-fhe-array.feature
@@ -2,6 +2,7 @@
 @order-07
 @core-api
 @fhe-array
+@gpu
 Feature: Homomorphic Array Summation
 
   This chapter describes homomorphic array summation and batch operations on collections of ciphertexts in the TFHE-Java library.

--- a/tfhe-java/src/test/resources/features/10-predefined-parameters-and-types.feature
+++ b/tfhe-java/src/test/resources/features/10-predefined-parameters-and-types.feature
@@ -2,6 +2,7 @@
 @order-10
 @section-PredefinedParameters
 @appendix
+@gpu
 Feature: Predefined Parameters and Cryptographic Types
 
   === Predefined Shortint Parameters

--- a/tfhe-java/src/test/resources/features/11-panama-binding-architecture.feature
+++ b/tfhe-java/src/test/resources/features/11-panama-binding-architecture.feature
@@ -2,6 +2,7 @@
 @order-11
 @section-PanamaBinding
 @appendix
+@gpu
 Feature: Project Panama and FFM Binding Architecture
 
   === Project Panama & FFM API

--- a/tfhe-java/src/test/resources/features/12-native-compilation-and-bindings.feature
+++ b/tfhe-java/src/test/resources/features/12-native-compilation-and-bindings.feature
@@ -2,6 +2,7 @@
 @order-12
 @section-NativeCompilation
 @appendix
+@gpu
 Feature: Native Compilation and Binding Generation
 
   === Dynamic C-API Compilation (Rust)

--- a/tfhe-java/src/test/resources/features/98-glossary.feature
+++ b/tfhe-java/src/test/resources/features/98-glossary.feature
@@ -1,6 +1,7 @@
 @asciidoc
 @order-98
 @glossary
+@gpu
 Feature: Glossary
 
   [glossary]
@@ -17,11 +18,21 @@ Feature: Glossary
   [[carry,Carry]]Carry::
   Extra bits that may be needed when operations on encrypted values exceed the original interval. TFHE-rs uses padding bits on the most significant bits to accommodate carries.
 
+  [[compressed-server-key,CompressedServerKey]]CompressedServerKey::
+  The **canonical server key** in TFHE-Java. A compact representation from which both a CPU `ServerKey`
+  and a GPU `CudaServerKey` can be derived via decompression.
+  This is the key format that clients should serialize and send to remote servers.
+  Calling `.use()` on a `CompressedServerKey` activates FHE operations transparently:
+  it always sets the CPU server key, and additionally sets the CUDA server key when `tfhe.gpu=true`.
+  See also: <<server-key,Server Key>>, <<client-key,Client Key>>.
+
   [[ciphertext,Ciphertext]]Ciphertext::
   An encrypted value consisting of a mask and body, computed using an LWE secret key. Fresh ciphertexts result from encryption, while derived ciphertexts result from operations.
 
   [[client-key,Client Key]]Client Key::
-  The secret key used by the client to encrypt and decrypt data. It must be kept private and secure.
+  The secret key used by the client to encrypt and decrypt data. It must be kept private and never shared.
+  It is the root of trust: all other keys are ultimately derived from it.
+  See also: <<compressed-server-key,CompressedServerKey>>, <<public-key,Public Key>>.
 
   [[fhe,FHE]]FHE::
   Fully Homomorphic Encryption - a cryptographic scheme that allows arbitrary computations on encrypted data without decrypting it.
@@ -75,7 +86,11 @@ Feature: Glossary
   The private key consisting of n random integers used to encrypt and decrypt LWE ciphertexts. Also known as the LWE secret key.
 
   [[server-key,Server Key]]Server Key::
-  The public evaluation key used by the server to perform homomorphic operations on encrypted data without being able to decrypt it.
+  A CPU-only decompressed evaluation key obtained from a `CompressedServerKey` via `.decompress()`.
+  Enables the server to perform homomorphic operations on encrypted data without being able to decrypt it.
+  Used primarily as a **conformant key** when deserializing ciphertexts.
+  Does not support GPU activation — use `CompressedServerKey.use()` for transparent CPU/GPU activation.
+  See also: <<compressed-server-key,CompressedServerKey>>.
 
   [[tfhe,TFHE]]TFHE::
   Torus Fully Homomorphic Encryption - a FHE scheme that enables fast homomorphic operations on booleans, integers, and reals using Learning With Errors over the torus.

--- a/tfhe-java/src/test/resources/features/99-bibliography.feature
+++ b/tfhe-java/src/test/resources/features/99-bibliography.feature
@@ -1,6 +1,7 @@
 @asciidoc
 @order-99
 @bibliography
+@gpu
 Feature: Bibliography
 
   [bibliography]


### PR DESCRIPTION
This PR consolidates several library simplifications, SOLID design improvements, and transparent GPU support:

### 1. Transparent GPU Routing & Thread Synchronization (`GpuRouter`)
- Routes FHE operations dynamically based on CPU/GPU capability before the native call is made.
- Adds `ThreadLocal<Boolean> IN_THREADING_CONTEXT` flag in `TfheThreadingContext` to bypass GPU execution during parallel Rayon operations.
- Dynamically updates keys on the dedicated `tfhe-gpu-executor` thread when keys change between tests.
- Consolidates duplicated exception catch-and-wrap logic via a generic `submitToGpu(Callable)` helper.

### 2. Centralized Factories (`Fhe` & `FheRegistry`)
- Introduces `Fhe.java` as a centralized, type-safe entry-point for generic static factory methods (`encrypt`, `deserialize`).
- Adds dynamic registry mapping for `FheTypeHandles` in `FheRegistry.java`.
- Refactored all 32 concrete FHE types to register their handles in a static initializer block and delegate static factory calls to `Fhe.java`.
- Resolved static initialization illegal forward reference issues by adjusting block ordering.

### 3. LSP Correctness for `abs()`
- Renamed the base class `abs()` implementation to `absImpl()` and changed visibility to `protected final`.
- Removed `abs()` from `AbstractFheUnsignedInteger.java` to avoid runtime `UnsupportedOperationException`.
- Declared `abs()` in `FheSignedInteger` and implemented it in all 16 signed `FheInt*` classes by delegating to `absImpl()`.
- Updated test verification in `FheTypesTest` to test `abs()` using pattern matching on `FheSignedInteger`.

### 4. Conditional Refactoring (`FheConditional`)
- Introduced the `FheConditional<T>` interface for `ifThenElse` operations.
- Made `FheType` extend `FheConditional`.
- Refactored static `ifThenElse` to an instance method in `AbstractFheType` and `FheBool`.
- Updated concrete types' static `ifThenElse` methods to act as delegates.

### 5. Verification
- Fully verified all 424 unit and integration tests passing in both CPU and GPU modes.
